### PR TITLE
Added .frozen to sys path to prefer frozen modules

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.insert(0, ".frozen")  # prefer frozen modules over local
+
 import adafruit_lis3dh
 import adafruit_thermistor
 import analogio


### PR DESCRIPTION
Express class will now prefer frozen modules over local versions. This will resolve memory allocation failures when including the entire library bundle on the CPX.