### PR TITLE
Added error to cpx.shake for incompatible CircuitPython versions

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -168,7 +168,8 @@ class Express:
         try:
             return self._lis3dh.shake()
         except AttributeError:
-            raise RuntimeError("Oops! You need a newer version of CircuitPython (2.2.0 or greater) to use cpx.shake.")
+            raise RuntimeError("Oops! You need a newer version of CircuitPython "
+                               "(2.2.0 or greater) to use cpx.shake.")
 
     @property
     def touch_A1(self): # pylint: disable=invalid-name

--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -165,8 +165,10 @@ class Express:
               if cpx.shake(shake_threshold=20):
                   print("Shake detected more easily than before!")
         """
-        return self._lis3dh.shake()
-
+        try:
+            return self._lis3dh.shake()
+        except AttributeError:
+            raise RuntimeError("Oops! You need a newer version of CircuitPython (2.2.0 or greater) to use cpx.shake.")
 
     @property
     def touch_A1(self): # pylint: disable=invalid-name


### PR DESCRIPTION
Error checking for `cpx.shake` when incompatible.