### PR TITLE
Init OK on 2.1.0

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -119,7 +119,10 @@ class Express:     # pylint: disable=too-many-public-methods
         self._lis3dh.range = adafruit_lis3dh.RANGE_8_G
 
         # Initialise tap:
-        self._lis3dh.set_tap(2, 18, time_limit=4, time_latency=17, time_window=110)
+        try:
+            self._lis3dh.set_tap(2, 18, time_limit=4, time_latency=17, time_window=110)
+        except AttributeError:
+            pass
         self._last_tap = False
 
     @property


### PR DESCRIPTION
LIS3DH doesn't have `set_tap` on 2.1.0.

Fixes #24 