### PR TITLE
Resolves issues using play_file and start/stop_tone

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -649,6 +649,8 @@ class Express:     # pylint: disable=too-many-public-methods
         # Stop playing any tones.
         if self._sample is not None and self._sample.playing:
             self._sample.stop()
+            self._sample.deinit()
+            self._sample = None
         self._speaker_enable.value = False
 
     def play_file(self, file_name):
@@ -677,6 +679,7 @@ class Express:     # pylint: disable=too-many-public-methods
             audio.play(file)
             while audio.playing:
                 pass
+            audio.deinit()
         else:
             audio = audioio.AudioOut(board.SPEAKER, open(file_name, "rb"))
             audio.play()

--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -672,22 +672,19 @@ class Express:     # pylint: disable=too-many-public-methods
                      cpx.play_file("rimshot.wav")
         """
         # Play a specified file.
+        self.stop_tone()
         self._speaker_enable.value = True
-        try:
-            if sys.implementation.version[0] >= 3:
-                audio = audioio.AudioOut(board.SPEAKER)
-                file = audioio.WaveFile(open(file_name, "rb"))
-                audio.play(file)
+        if sys.implementation.version[0] >= 3:
+            with audioio.AudioOut(board.SPEAKER) as audio:
+                wavefile = audioio.WaveFile(open(file_name, "rb"))
+                audio.play(wavefile)
                 while audio.playing:
                     pass
-                audio.deinit()
-            else:
-                audio = audioio.AudioOut(board.SPEAKER, open(file_name, "rb"))
+        else:
+            with audioio.AudioOut(board.SPEAKER, open(file_name, "rb")) as audio:
                 audio.play()
                 while audio.playing:
                     pass
-        except RuntimeError:
-            pass
         self._speaker_enable.value = False
 
 

--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -687,7 +687,7 @@ class Express:     # pylint: disable=too-many-public-methods
                 while audio.playing:
                     pass
         except RuntimeError:
-            pass
+            pass 
         self._speaker_enable.value = False
 
 

--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -687,7 +687,7 @@ class Express:     # pylint: disable=too-many-public-methods
                 while audio.playing:
                     pass
         except RuntimeError:
-            pass 
+            pass
         self._speaker_enable.value = False
 
 

--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -673,18 +673,21 @@ class Express:     # pylint: disable=too-many-public-methods
         """
         # Play a specified file.
         self._speaker_enable.value = True
-        if sys.implementation.version[0] >= 3:
-            audio = audioio.AudioOut(board.SPEAKER)
-            file = audioio.WaveFile(open(file_name, "rb"))
-            audio.play(file)
-            while audio.playing:
-                pass
-            audio.deinit()
-        else:
-            audio = audioio.AudioOut(board.SPEAKER, open(file_name, "rb"))
-            audio.play()
-            while audio.playing:
-                pass
+        try:
+            if sys.implementation.version[0] >= 3:
+                audio = audioio.AudioOut(board.SPEAKER)
+                file = audioio.WaveFile(open(file_name, "rb"))
+                audio.play(file)
+                while audio.playing:
+                    pass
+                audio.deinit()
+            else:
+                audio = audioio.AudioOut(board.SPEAKER, open(file_name, "rb"))
+                audio.play()
+                while audio.playing:
+                    pass
+        except RuntimeError:
+            pass
         self._speaker_enable.value = False
 
 


### PR DESCRIPTION
Added `deinit()` to both. You still get a `RuntimeError` of `DAC already in use` if you are currently playing a tone using `start_tone` and then try to `play_file` before ending the tone. Added `try` and `except` to `play_file` to avoid this error if these functions are used in this manner.