### PR TITLE
adjust sample length if needed for max sample rate

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -562,10 +562,9 @@ class Express:     # pylint: disable=too-many-public-methods
         for i in range(length):
             yield int(tone_volume * math.sin(2*math.pi*(i / length)) + shift)
 
-    def _generate_sample(self):
+    def _generate_sample(self, length=100):
         if self._sample is not None:
             return
-        length = 100
         self._sine_wave = array.array("H", Express._sine_sample(length))
         if sys.implementation.version[0] >= 3:
             self._sample = audioio.AudioOut(board.SPEAKER)
@@ -617,7 +616,10 @@ class Express:     # pylint: disable=too-many-public-methods
                      cpx.stop_tone()
         """
         self._speaker_enable.value = True
-        self._generate_sample()
+        length = 100
+        if length * frequency > 350000:
+            length = 350000 // frequency
+        self._generate_sample(length)
         # Start playing a tone of the specified frequency (hz).
         if sys.implementation.version[0] >= 3:
             self._sine_wave_sample.sample_rate = int(len(self._sine_wave) * frequency)


### PR DESCRIPTION
Adds check to go along with fix added for #40.

**BEFORE**
```python
Adafruit CircuitPython 3.0.2-2-gaf7a0ee on 2018-09-19; Adafruit CircuitPlayground Express with samd21g18
>>> from adafruit_circuitplayground.express import cpx
>>> cpx.play_tone(330, 1)
>>> cpx.play_tone(660, 1)
>>> cpx.play_tone(3200, 1)
>>> cpx.play_tone(4200, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "adafruit_circuitplayground/express.py", line 594, in play_tone
  File "adafruit_circuitplayground/express.py", line 625, in start_tone
ValueError: Sample rate too high. It must be less than 350000
>>>
```

**AFTER**
```python
Adafruit CircuitPython 3.0.2-2-gaf7a0ee on 2018-09-19; Adafruit CircuitPlayground Express with samd21g18
>>> from adafruit_circuitplayground.express import cpx
>>> cpx.play_tone(330, 1)
>>> cpx.play_tone(660, 1)
>>> cpx.play_tone(3200, 1)
>>> cpx.play_tone(4200, 1)
>>> 
```