### PR TITLE
adjust frozen path order only if necessary

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -38,7 +38,14 @@ import math
 import sys
 import time
 # pylint: disable=wrong-import-position
-sys.path.insert(0, ".frozen")  # prefer frozen modules over local
+try:
+    lib_index = sys.path.index("/lib")        # pylint: disable=invalid-name
+    if lib_index < sys.path.index(".frozen"):
+        # Prefer frozen modules over those in /lib.
+        sys.path.insert(lib_index, ".frozen")
+except ValueError:
+    # Don't change sys.path if it doesn't contain "lib" or ".frozen".
+    pass
 
 import adafruit_lis3dh
 import adafruit_thermistor


### PR DESCRIPTION
Put `.frozen` before `lib/` in `sys.path` only if necessary, and only if both are in `sys.path`. This allows testing of non-frozen libraries in `/`, and does not adjust the path if `.frozen` is already before `/lib`.