### PR TITLE
Revert "Add Adafruit-Blinka to requirements.txt"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Adafruit-Blinka
+


### PR DESCRIPTION
Reverts adafruit/Adafruit_CircuitPython_CircuitPlayground#47

Will not be on PyPI, does not require Adafruit-Blinka. 

Add to whitelist on Adabot per: https://github.com/adafruit/adabot/issues/70
