### PR TITLE
Add option for volume control, not needed but can be use. Play a melody added.

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -653,6 +653,49 @@ class Express:     # pylint: disable=too-many-public-methods
             self._sample = None
         self._speaker_enable.value = False
 
+    def play_melody(self, frequencies, durations, speed=10):
+        """ Play a melody using notes and beats, rests are 0 frequency.
+
+        :param int frequency: The frequency of the tone in Hz
+        :param float duration: The duration of the tone in seconds
+        :param float speed: Optional parameter, fine tune duration
+
+        .. image :: ../docs/_static/speaker.jpg
+          :alt: Onboard speaker
+
+        .. code-block:: python
+
+            from adafruit_circuitplayground.express import cpx
+
+            notes = [698, 880, 988, 698, 880, 988, 698, 880, 988,
+            1319, 1175, 988, 1047, 988, 784, 659, 587, 659, 784, 659,
+            698, 880, 988, 698, 880, 988, 698, 880, 988, 1319,
+            1175, 988, 1047, 1319, 988, 784, 988, 784, 587, 659,
+            587, 659, 698, 784, 880, 988, 1047, 988, 659, 698,
+            784, 880, 988, 1047, 1175, 1319, 1397, 1568,
+            587, 659, 698, 784, 880, 988, 1047, 988, 659,
+            784, 698, 880, 784, 988, 880, 1047, 988, 1175, 1047,
+            1319, 1175, 1397, 1319, 1319, 1397, 1175, 1319,
+            0, 0, 0]
+
+            beats= [2, 2, 4, 2, 2, 4, 2, 2, 2, 2, 4, 2, 2, 2, 2, 8, 2, 2, 2,
+            10, 2, 2, 4, 2, 2, 4, 2, 2, 2, 2, 4, 2, 2, 2, 2, 8, 2, 2, 2, 10,
+            2, 2, 4, 2, 2, 4, 2, 2, 8, 2, 2, 4, 2, 2, 4, 2, 2, 8,
+            2, 2, 4, 2, 2, 4, 2, 2, 8,
+            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 2, 6,
+            4, 2, 2]
+
+            while True:
+                cpx.play_melody(notes, beats)
+        """
+        # Play a melody.
+        for idx, frequency in enumerate(frequencies):
+            if frequency != 0:
+                self.start_tone(frequency)
+            time.sleep(durations[idx]/speed)
+            self._sample.stop()
+        self.stop_tone()
+
     def play_file(self, file_name):
         """ Play a .wav file using the onboard speaker.
 


### PR DESCRIPTION
```python
from adafruit_circuitplayground.express import cpx

notes2 = [293, 440, 440, 0, 330, 494, 349, 523, 523, 0, 330, 494,
293, 440, 440, 0, 330, 494, 349, 523, 523, 0, 330, 494,
293, 349, 587, 293, 349, 587,
659, 698, 659, 698, 659, 523, 440,
440, 293, 349, 392, 440, 440, 293, 349, 392, 330,
293, 349, 587, 293, 349, 587,
659, 698, 659, 698, 659, 523, 440,
440, 293, 349, 392, 440,
440, 293]

beats2 = [2, 2, 2, 1, 1, 4, 2, 2, 2, 1, 1, 4,
2, 2, 2, 1, 1, 4, 2, 2, 2, 1, 1, 4,
1, 1, 4, 1, 1, 4,
3, 1, 1, 1, 1, 1, 4, 2, 2, 1, 1, 6,
2, 2, 1, 1, 6,
1, 1, 4, 1, 1, 4,
3, 1, 1, 1, 1, 1, 4, 2, 2, 1, 1, 6,
2, 6]

newvol = -(2**12)

while True:
    cpx.play_melody(notes2, beats2, speed=10, volume=newvol)
```
example of new melody
```python
from adafruit_circuitplayground.express import cpx

newvol = -(2**12)

cpx.play_tone(220, 2, newvol)
```
example of just volume control