### PR TITLE
Remove unneeded variables and conditions

### DIFF
--- a/examples/circuitplayground_acceleration_neopixels.py
+++ b/examples/circuitplayground_acceleration_neopixels.py
@@ -18,10 +18,4 @@ while True:
         B = 0
         x, y, z = cpx.acceleration
         print((x, y, z))
-        if x:
-            R = R + abs(int(x))
-        if y:
-            G = G + abs(int(y))
-        if z:
-            B = B + abs(int(z))
-        cpx.pixels.fill((R, G, B))
+        cpx.pixels.fill(((R + abs(int(x))), (G + abs(int(y))), (B + abs(int(z)))))


### PR DESCRIPTION
I’ve recently discovered these helpful examples. I’d like to offer some code simplifications.

### Accelerometer
If I’m not mistaken, x, y, and z are never (or **extremely** rarely) 0, so the “if”s are not needed, and then the R, G, B variables are not needed. Did I miss something?

### ~~Buttons~~
~~I find my new Python students are comfortable with conditional expressions, but if the
consensus here is that the if statement is preferred, I can remove that commit.~~