### PR TITLE
Create an acceleration to LEDs example

### DIFF
--- a/examples/circuitplayground_acceleration_mapping_neopixels.py
+++ b/examples/circuitplayground_acceleration_mapping_neopixels.py
@@ -13,7 +13,7 @@ to green.
 This video walks you through the code: https://youtu.be/eNpPLbYx-iA
 """
 
-from time import sleep
+import time
 from adafruit_circuitplayground.express import cpx
 
 cpx.pixels.brightness = 0.2  # Adjust overall brightness as desired, between 0 and 1
@@ -28,25 +28,21 @@ def color_amount(accel_component):
     return round(normalized_accel * 255)                        # Convert to 0–255
 
 
-def fmt_accel(acceleration):
+def format_acceleration():
     return ', '.join(('{:>6.2f}'.format(axis_value) for axis_value in acceleration))
 
 
-def fmt_rgb(rgb_amounts):
+def format_rgb():
     return ', '.join(('{:>3d}'.format(rgb_amount) for rgb_amount in rgb_amounts))
 
 
-def log_values(acceleration, rgb_amounts):
-    print('({}) ==> ({})'.format(fmt_accel(acceleration), fmt_rgb(rgb_amounts)))
-
-
-def process():
-    acceleration = cpx.acceleration
-    rgb_amounts = [color_amount(axis_value) for axis_value in acceleration]
-    cpx.pixels.fill(rgb_amounts)
-    log_values(acceleration, rgb_amounts)
+def log_values():
+    print('({}) ==> ({})'.format(format_acceleration(), format_rgb()))
 
 
 while True:
-    process()
-    sleep(0.1)
+    acceleration = cpx.acceleration
+    rgb_amounts = [color_amount(axis_value) for axis_value in acceleration]
+    cpx.pixels.fill(rgb_amounts)
+    log_values()
+    time.sleep(0.1)

--- a/examples/circuitplayground_acceleration_mapping_neopixels.py
+++ b/examples/circuitplayground_acceleration_mapping_neopixels.py
@@ -1,0 +1,52 @@
+"""Maps acceleration (tilt) to Neopixel colors.
+
+x, y, and z acceleration components map to red, green and blue,
+respectively.
+
+When the CPX is level, the lights are blue because there is no acceleration
+on x or y, but on z, gravity pulls at 9.81 meters per second per second (m/s²).
+When banking, the vertical (z) axis is no longer directly aligned with gravity,
+so the blue decreases, and red increases because gravity is now pulling more
+along the x axis. Similarly, when changing the pitch from level, we see blue change
+to green.
+
+This video walks you through the code: https://youtu.be/eNpPLbYx-iA
+"""
+
+from time import sleep
+from adafruit_circuitplayground.express import cpx
+
+cpx.pixels.brightness = 0.2  # Adjust overall brightness as desired, between 0 and 1
+
+
+def color_amount(accel_component):
+    """Convert acceleration component (x, y, or z) to color amount (r, g, or b)"""
+    standard_gravity = 9.81  # Acceleration (m/s²) due to gravity at the earth’s surface
+    accel_magnitude = abs(accel_component)                      # Ignore the direction
+    constrained_accel = min(accel_magnitude, standard_gravity)  # Constrain values
+    normalized_accel = constrained_accel / standard_gravity     # Convert to 0–1
+    return round(normalized_accel * 255)                        # Convert to 0–255
+
+
+def fmt_accel(acceleration):
+    return ', '.join(('{:>6.2f}'.format(axis_value) for axis_value in acceleration))
+
+
+def fmt_rgb(rgb_amounts):
+    return ', '.join(('{:>3d}'.format(rgb_amount) for rgb_amount in rgb_amounts))
+
+
+def log_values(acceleration, rgb_amounts):
+    print('({}) ==> ({})'.format(fmt_accel(acceleration), fmt_rgb(rgb_amounts)))
+
+
+def process():
+    acceleration = cpx.acceleration
+    rgb_amounts = [color_amount(axis_value) for axis_value in acceleration]
+    cpx.pixels.fill(rgb_amounts)
+    log_values(acceleration, rgb_amounts)
+
+
+while True:
+    process()
+    sleep(0.1)


### PR DESCRIPTION
Inspired by `circuitplayground_acceleration_neopixels.py`, this example is more explicit about the mapping between acceleration values and color values. It constrains the absolute values of the inputs to standard gravity, then maps that range exactly onto 0–255. A comment in the code points to an explanatory video: https://youtu.be/eNpPLbYx-iA .