### PR TITLE
express.py: adapt to 'audiocore', retaining compatibility with earlier versions

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -51,6 +51,10 @@ import adafruit_lis3dh
 import adafruit_thermistor
 import analogio
 import audioio
+try:
+    import audiocore
+except ImportError:
+    audiocore = audioio
 import board
 import busio
 import digitalio
@@ -575,7 +579,7 @@ class Express:     # pylint: disable=too-many-public-methods
         self._sine_wave = array.array("H", Express._sine_sample(length))
         if sys.implementation.version[0] >= 3:
             self._sample = audioio.AudioOut(board.SPEAKER)
-            self._sine_wave_sample = audioio.RawSample(self._sine_wave)
+            self._sine_wave_sample = audiocore.RawSample(self._sine_wave)
         else:
             raise NotImplementedError("Please use CircuitPython 3.0 or higher.")
 
@@ -683,7 +687,7 @@ class Express:     # pylint: disable=too-many-public-methods
         self._speaker_enable.value = True
         if sys.implementation.version[0] >= 3:
             with audioio.AudioOut(board.SPEAKER) as audio:
-                wavefile = audioio.WaveFile(open(file_name, "rb"))
+                wavefile = audiocore.WaveFile(open(file_name, "rb"))
                 audio.play(wavefile)
                 while audio.playing:
                     pass


### PR DESCRIPTION
Testing performed: None, I gave away my CPX.

I made and tested similar changes earlier on a CPX with 4.1 and 5.0, freezing the module in with the circuitpython build, and it seemed to work.

I anticipate having another CPX in hand next week, I'll perform testing and follow up here if nobody else has been able to validate these changes.