### PR TITLE
WIP: Improve Audio

### DIFF
--- a/examples/advanced_examples/modified_express_audio.py
+++ b/examples/advanced_examples/modified_express_audio.py
@@ -1,0 +1,82 @@
+import array
+import math
+import time
+import board
+import digitalio
+import audioio
+try:
+    import audiocore
+except ImportError:
+    audiocore = audioio
+
+
+class ModifiedExpressAudio:
+    def __init__(self):
+        self._max_sample_rate = 350_000
+        self._highest_supported_frequency = 20_000
+        self._normal_sample_length = 300
+        self._samples_change_frequency = self._max_sample_rate / self._normal_sample_length
+        self._sample_lengths = (
+            self._normal_sample_length,
+            self._max_sample_rate / self._highest_supported_frequency)
+        self._speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
+        self._speaker_enable.switch_to_output(value=False)
+        self._speaker_enable.value = True
+        self._raw_samples = tuple(self._generate_samples())
+        self._audio_out = audioio.AudioOut(board.SPEAKER)
+
+    @staticmethod
+    def _sine_waveform(length, amplitude=1):
+        max_amplitude = 2 ** 15 - 1
+        angle = 0.0
+        angle_change_per_sample = 2 * math.pi / length
+        for _ in range(length):
+            yield int(amplitude * max_amplitude * (math.sin(angle) + 1))
+            angle += angle_change_per_sample
+
+    def _generate_samples(self):
+        return [audiocore.RawSample(array.array("H", ModifiedExpressAudio._sine_waveform(length)))
+                for length in self._sample_lengths]
+
+    def start_tone(self, frequency):
+        if frequency <= self._highest_supported_frequency:
+            # Start playing a tone of the specified frequency (hz).
+            samples_index = 0 if frequency < self._samples_change_frequency else 1
+            length = self._sample_lengths[samples_index]
+            sample_to_play = self._raw_samples[samples_index]
+            sample_to_play.sample_rate = int(length * frequency)
+            if not self._audio_out.playing:
+                self._audio_out.play(sample_to_play, loop=True)
+
+    def stop_tone(self):
+        if self._audio_out is not None and self._audio_out.playing:
+            self._audio_out.stop()
+
+    def clear_audio(self):
+        self.stop_tone()
+        if self._audio_out is not None:
+            self._audio_out.deinit()
+            self._audio_out = None
+
+
+cpx = ModifiedExpressAudio()
+
+STARTING_NOTE_FREQ = 32.71  # C1
+STARTING_OCTAVE = 1
+NOTE_SPACING_SECONDS = 0.2
+KEYS = 'C Db D Eb E F Gb G Ab A Bb B'.split(' ')  # Using b to represent ♭
+
+
+for reset in (False, ):
+    next_note_play_time = time.monotonic()
+    for octave_index in range(9):
+        for semitone_index in range(12):
+            semitones_above_start = octave_index * 12 + semitone_index
+            freq = STARTING_NOTE_FREQ * 2 ** (semitones_above_start / 12)
+            print(KEYS[semitone_index % 12] + str(octave_index + STARTING_OCTAVE), '\t', freq)
+            cpx.start_tone(freq)
+            next_note_play_time += NOTE_SPACING_SECONDS
+            time.sleep(next_note_play_time - time.monotonic())
+            cpx.stop_tone()
+    time.sleep(0.5)
+cpx.clear_audio()

--- a/examples/advanced_examples/modified_express_audio.py
+++ b/examples/advanced_examples/modified_express_audio.py
@@ -14,15 +14,17 @@ class ModifiedExpressAudio:
     def __init__(self):
         self._max_sample_rate = 350_000
         self._highest_supported_frequency = 20_000
-        self._normal_sample_length = 300
+        self._normal_sample_length = 100  # This can be just 2 for square wave
         self._samples_change_frequency = self._max_sample_rate / self._normal_sample_length
         self._sample_lengths = (
             self._normal_sample_length,
-            self._max_sample_rate / self._highest_supported_frequency)
+            int(self._max_sample_rate / self._highest_supported_frequency))
         self._speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
         self._speaker_enable.switch_to_output(value=False)
         self._speaker_enable.value = True
-        self._raw_samples = tuple(self._generate_samples())
+        # List of samples lists for each of sine and square waveforms
+        self._raw_samples = self._generate_samples()
+        self._waveform_type_index = 0
         self._audio_out = audioio.AudioOut(board.SPEAKER)
 
     @staticmethod
@@ -34,19 +36,25 @@ class ModifiedExpressAudio:
             yield int(amplitude * max_amplitude * (math.sin(angle) + 1))
             angle += angle_change_per_sample
 
+    @staticmethod
+    def _square_waveform(length, amplitude=1):
+        max_amplitude = 2 ** 16 - 1
+        top = int(amplitude * max_amplitude)
+        return (top if i < length / 2 else 0 for i in range(length))
+
     def _generate_samples(self):
-        return [audiocore.RawSample(array.array("H", ModifiedExpressAudio._sine_waveform(length)))
-                for length in self._sample_lengths]
+        'For each of sine and square waveforms, generate one sample each for low and high ranges'
+        return [[audiocore.RawSample(array.array("H", fn(length)))
+            for length in self._sample_lengths]
+            for fn in (ModifiedExpressAudio._sine_waveform, ModifiedExpressAudio._square_waveform)]
 
     def start_tone(self, frequency):
         if frequency <= self._highest_supported_frequency:
-            # Start playing a tone of the specified frequency (hz).
             samples_index = 0 if frequency < self._samples_change_frequency else 1
             length = self._sample_lengths[samples_index]
-            sample_to_play = self._raw_samples[samples_index]
+            sample_to_play = self._raw_samples[self._waveform_type_index][samples_index]
             sample_to_play.sample_rate = int(length * frequency)
-            if not self._audio_out.playing:
-                self._audio_out.play(sample_to_play, loop=True)
+            self._audio_out.play(sample_to_play, loop=True)
 
     def stop_tone(self):
         if self._audio_out is not None and self._audio_out.playing:
@@ -59,24 +67,31 @@ class ModifiedExpressAudio:
             self._audio_out = None
 
 
+def play_tone():
+    cpx.start_tone(220)
+    time.sleep(5)
+
+
+def play_scale():
+    STARTING_NOTE_FREQ = 32.70319566257483  # C1
+    STARTING_OCTAVE = 1
+    NOTE_SPACING_SECONDS = 0.2
+    KEYS = 'C Db D Eb E F Gb G Ab A Bb B'.split(' ')  # Using b to represent ♭
+
+    for i in range(1, 2):
+        cpx._waveform_type_index = i
+        next_note_play_time = time.monotonic()
+        for octave_index in range(7):
+            for semitone_index in range(12):
+                semitones_above_start = octave_index * 12 + semitone_index
+                freq = STARTING_NOTE_FREQ * 2 ** (semitones_above_start / 12)
+                print(KEYS[semitone_index % 12] + str(octave_index + STARTING_OCTAVE), '\t', freq)
+                cpx.start_tone(freq)
+                next_note_play_time += NOTE_SPACING_SECONDS
+                time.sleep(next_note_play_time - time.monotonic())
+                # Not calling stop_tone()
+
+
 cpx = ModifiedExpressAudio()
-
-STARTING_NOTE_FREQ = 32.71  # C1
-STARTING_OCTAVE = 1
-NOTE_SPACING_SECONDS = 0.2
-KEYS = 'C Db D Eb E F Gb G Ab A Bb B'.split(' ')  # Using b to represent ♭
-
-
-for reset in (False, ):
-    next_note_play_time = time.monotonic()
-    for octave_index in range(9):
-        for semitone_index in range(12):
-            semitones_above_start = octave_index * 12 + semitone_index
-            freq = STARTING_NOTE_FREQ * 2 ** (semitones_above_start / 12)
-            print(KEYS[semitone_index % 12] + str(octave_index + STARTING_OCTAVE), '\t', freq)
-            cpx.start_tone(freq)
-            next_note_play_time += NOTE_SPACING_SECONDS
-            time.sleep(next_note_play_time - time.monotonic())
-            cpx.stop_tone()
-    time.sleep(0.5)
+play_scale()
 cpx.clear_audio()

--- a/examples/advanced_examples/modified_express_audio.py
+++ b/examples/advanced_examples/modified_express_audio.py
@@ -11,24 +11,28 @@ except ImportError:
 
 
 class ModifiedExpressAudio:
+    'An enhanced set of audio features, perhaps to augment those in the current Adafruit library'
     def __init__(self):
-        self._max_sample_rate = 350_000
         self._highest_supported_frequency = 20_000
-        self._normal_sample_length = 100  # This can be just 2 for square wave
-        self._samples_change_frequency = self._max_sample_rate / self._normal_sample_length
-        self._sample_lengths = (
-            self._normal_sample_length,
-            int(self._max_sample_rate / self._highest_supported_frequency))
         self._speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
         self._speaker_enable.switch_to_output(value=False)
-        self._speaker_enable.value = True
-        # List of samples lists for each of sine and square waveforms
-        self._raw_samples = self._generate_samples()
-        self._waveform_type_index = 0
+        self._speaker_enable.value = False
+        self._volume = 1.0
         self._audio_out = audioio.AudioOut(board.SPEAKER)
+        self._generators = (
+            (ModifiedExpressAudio._sine_waveform, 100),
+            (ModifiedExpressAudio._square_waveform, 2),
+            (ModifiedExpressAudio._triangle_waveform, 50)
+        )
+        self._waveform_index = 0
+        self._create_waveform()
+
+    def _create_waveform(self):
+        generator, length = self._generators[self._waveform_index]
+        self._audiocore_raw_sample = audiocore.RawSample(array.array("H", generator(length, self._volume)))
 
     @staticmethod
-    def _sine_waveform(length, amplitude=1):
+    def _sine_waveform(length, amplitude=1.0):
         max_amplitude = 2 ** 15 - 1
         angle = 0.0
         angle_change_per_sample = 2 * math.pi / length
@@ -37,24 +41,32 @@ class ModifiedExpressAudio:
             angle += angle_change_per_sample
 
     @staticmethod
-    def _square_waveform(length, amplitude=1):
+    def _square_waveform(length, amplitude=1.0):
+        assert length == 2
+        loudest_audible_amplitude = 0.5
+        max_amplitude = 2 ** 16 - 1
+        return 0, int(loudest_audible_amplitude * amplitude * max_amplitude)
+
+    @staticmethod
+    def _triangle_waveform(length, amplitude=1.0):
         max_amplitude = 2 ** 16 - 1
         top = int(amplitude * max_amplitude)
-        return (top if i < length / 2 else 0 for i in range(length))
+        dx = 2 / length
+        x = -1
+        while x < 1:
+            yield round(top * (-abs(x) + 1))
+            x += dx
 
-    def _generate_samples(self):
-        'For each of sine and square waveforms, generate one sample each for low and high ranges'
-        return [[audiocore.RawSample(array.array("H", fn(length)))
-            for length in self._sample_lengths]
-            for fn in (ModifiedExpressAudio._sine_waveform, ModifiedExpressAudio._square_waveform)]
+    def set_volume(self, volume):
+        self._volume = volume
+        self._create_waveform()
 
     def start_tone(self, frequency):
-        if frequency <= self._highest_supported_frequency:
-            samples_index = 0 if frequency < self._samples_change_frequency else 1
-            length = self._sample_lengths[samples_index]
-            sample_to_play = self._raw_samples[self._waveform_type_index][samples_index]
-            sample_to_play.sample_rate = int(length * frequency)
-            self._audio_out.play(sample_to_play, loop=True)
+        if frequency <= self._highest_supported_frequency and self._volume > 0:
+            self._audiocore_raw_sample.sample_rate = int(self._generators[self._waveform_index][1] * frequency)
+            self._speaker_enable.value = False
+            self._audio_out.play(self._audiocore_raw_sample, loop=True)
+            self._speaker_enable.value = True
 
     def stop_tone(self):
         if self._audio_out is not None and self._audio_out.playing:
@@ -66,32 +78,71 @@ class ModifiedExpressAudio:
             self._audio_out.deinit()
             self._audio_out = None
 
+    def select_waveform(self, waveform_index):
+        self._waveform_index = waveform_index
+        self._create_waveform()
 
-def play_tone():
-    cpx.start_tone(220)
-    time.sleep(5)
 
+def run_demos():
+    C1_FREQ = 32.70319566257483
 
-def play_scale():
-    STARTING_NOTE_FREQ = 32.70319566257483  # C1
-    STARTING_OCTAVE = 1
-    NOTE_SPACING_SECONDS = 0.2
-    KEYS = 'C Db D Eb E F Gb G Ab A Bb B'.split(' ')  # Using b to represent ♭
+    def play_midi(note):
+        if 24 <= note <= 108:
+            semitones_above_c1 = note - 24
+            freq = C1_FREQ * 2 ** (semitones_above_c1 / 12)
+            cpx.start_tone(freq)
 
-    for i in range(1, 2):
-        cpx._waveform_type_index = i
+    def arpeggio():
+        HIGHEST_OCTAVE = 4
+        for octave in range(HIGHEST_OCTAVE + 1):
+            for note in (24, 28, 31):
+                play_midi(octave * 12 + note)
+                time.sleep(.2)
+        play_midi((HIGHEST_OCTAVE + 1) * 12 + 24)
+        time.sleep(0.3)
+
+    def scale():
+        STARTING_NOTE_FREQ = C1_FREQ
+        STARTING_OCTAVE = 1
+        NOTE_SPACING_SECONDS = 0.2
+        KEYS = 'C Db D Eb E F Gb G Ab A Bb B'.split(' ')  # Using b to represent ♭
+
         next_note_play_time = time.monotonic()
-        for octave_index in range(7):
+        for octave_index in range(5):
             for semitone_index in range(12):
                 semitones_above_start = octave_index * 12 + semitone_index
                 freq = STARTING_NOTE_FREQ * 2 ** (semitones_above_start / 12)
                 print(KEYS[semitone_index % 12] + str(octave_index + STARTING_OCTAVE), '\t', freq)
-                cpx.start_tone(freq)
                 next_note_play_time += NOTE_SPACING_SECONDS
-                time.sleep(next_note_play_time - time.monotonic())
+                cpx.start_tone(freq)
+                sleep_time = max(0.0, next_note_play_time - time.monotonic())
+                time.sleep(sleep_time)
                 # Not calling stop_tone()
 
+    def changing_volume():
+        for i in range(11):
+            v = i / 10
+            print(v)
+            cpx.set_volume(v)
+            play_midi(60)
+            time.sleep(1)
 
-cpx = ModifiedExpressAudio()
-play_scale()
-cpx.clear_audio()
+    cpx = ModifiedExpressAudio()
+    functions = (
+        ('Arpeggio', arpeggio),
+        ('Scale', scale),
+        ('Changing Volume', changing_volume),
+    )
+    cpx.set_volume(1.0)
+    waves = 'Sine Square Triangle'.split()
+    for fn, f in functions:
+        print(fn)
+        for waveform_index, name in enumerate(waves):
+            print(name)
+            cpx.select_waveform(waveform_index)
+            f()
+    cpx.clear_audio()
+
+
+if __name__ == '__main__':
+    run_demos()


### PR DESCRIPTION
Create a set of improvements for the Express class’s audio features to improve performance and—later—to even volumes across the frequency range.

The existing start_tone method is slow because it generates a waveform prior to playing each tone. I propose to change this.

There is a limit of 350,000 sample points per second. So we can’t use 100 points per sample above 3,500 Hz.

This changed code generates two samples, one for each of two ranges of frequencies. 

I added a square wave generator, and it’s much louder and has a much more consistent volume across the entire range (except for the several screaming resonating notes). If you run the program as is now, you’ll hear the square wave. 

@tannewt mentioned a new mixer feature coming, but simpler than that (and 4.x compatible) might be to generate multiple square waveforms (just four bytes apiece since they require only 2 values each) at some number of gradations, then add a volume argument to the API. Everything can stay compatible (except that the sound will change).

Also please see my status note in https://docs.google.com/document/d/1suvCpQSY2tuw4wjyZ9G-BFId2iovcZSiA07r3W7gmrs/edit.