### PR TITLE
Remove need for simpleio.

### DIFF
--- a/examples/circuitplayground_light_neopixels.py
+++ b/examples/circuitplayground_light_neopixels.py
@@ -1,23 +1,28 @@
-"""THIS EXAMPLE REQUIRES A SEPARATE LIBRARY BE LOADED ONTO YOUR CIRCUITPY DRIVE.
-This example requires the simpleio.mpy library.
-
-This example uses the light sensor on the CPX, located net to the picture of the eye on the board.
+"""
+This example uses the light sensor on the CPX, located next to the picture of the eye on the board.
 Once you have the library loaded, try shining a flashlight on your CPX to watch the number of
-NeoPixels lit up increase, or try covering up the light sensor to watch the number decrease."""
+NeoPixels lit up increase, or try covering up the light sensor to watch the number decrease.
+"""
+
 import time
 from adafruit_circuitplayground.express import cpx
-import simpleio
 
 cpx.pixels.auto_write = False
 cpx.pixels.brightness = 0.3
 
+
+def scale_range(value):
+    """Scale a value from 0-320 (light range) to 0-10 (the number of NeoPixels).
+    Allows remapping light value to pixel position."""
+    return int(value / 320 * 10)
+
+
 while True:
-    # light value remapped to pixel position
-    peak = simpleio.map_range(cpx.light, 0, 320, 0, 10)
+    peak = scale_range(cpx.light)
     print(cpx.light)
     print(int(peak))
 
-    for i in range(0, 10, 1):
+    for i in range(10):
         if i <= peak:
             cpx.pixels[i] = (0, 255, 255)
         else:

--- a/examples/circuitplayground_temperature_neopixels.py
+++ b/examples/circuitplayground_temperature_neopixels.py
@@ -1,6 +1,4 @@
-"""THIS EXAMPLE REQUIRES A SEPARATE LIBRARY BE LOADED ONTO YOUR CIRCUITPY DRIVE.
-This example requires the simpleio.mpy library.
-
+"""
 This example use the temperature sensor on the CPX, located next to the picture of the thermometer
 on the board. Try warming up the board to watch the number of NeoPixels lit up increase, or cooling
 it down to see the number decrease. You can set the min and max temperatures to make it more or
@@ -8,7 +6,6 @@ less sensitive to temperature changes.
 """
 import time
 from adafruit_circuitplayground.express import cpx
-import simpleio
 
 cpx.pixels.auto_write = False
 cpx.pixels.brightness = 0.3
@@ -17,13 +14,19 @@ cpx.pixels.brightness = 0.3
 minimum_temp = 24
 maximum_temp = 30
 
+
+def scale_range(value):
+    """Scale a value from the range of minimum_temp to maximum_temp (temperature range) to 0-10
+    (the number of NeoPixels). Allows remapping temperature value to pixel position."""
+    return int((value - minimum_temp) / (maximum_temp - minimum_temp) * 10)
+
+
 while True:
-    # temperature value remapped to pixel position
-    peak = simpleio.map_range(cpx.temperature, minimum_temp, maximum_temp, 0, 10)
+    peak = scale_range(cpx.temperature)
     print(cpx.temperature)
     print(int(peak))
 
-    for i in range(0, 10, 1):
+    for i in range(10):
         if i <= peak:
             cpx.pixels[i] = (0, 255, 255)
         else:


### PR DESCRIPTION
Examples function the same but no longer have a need for an extra library module.