### PR TITLE
Update to import options and examples

### DIFF
--- a/adafruit_circuitplayground/__init__.py
+++ b/adafruit_circuitplayground/__init__.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+"""Verifies which board is being used and imports the appropriate module."""
+
 import sys
 if sys.platform == 'nRF52840':
     from .bluefruit import cpb as cp

--- a/adafruit_circuitplayground/__init__.py
+++ b/adafruit_circuitplayground/__init__.py
@@ -1,0 +1,27 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2019 Kattni Rembor for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+if sys.platform == 'nRF52840':
+    from .bluefruit import cpb as cp
+elif sys.platform == 'Atmel SAMD21':
+    from .express import cpx as cp

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -39,7 +39,10 @@ CircuitPython base class for Circuit Playground.
 import math
 import array
 import time
-import audiocore
+try:
+    import audiocore
+except ImportError:
+    import audioio as audiocore
 import adafruit_lis3dh
 import adafruit_thermistor
 import analogio

--- a/examples/advanced_examples/circuitplayground_acceleration_mapping_neopixels.py
+++ b/examples/advanced_examples/circuitplayground_acceleration_mapping_neopixels.py
@@ -3,7 +3,7 @@
 x, y, and z acceleration components map to red, green and blue,
 respectively.
 
-When the CPX is level, the lights are blue because there is no acceleration
+When the Circuit Playground is level, the lights are blue because there is no acceleration
 on x or y, but on z, gravity pulls at 9.81 meters per second per second (m/s²).
 When banking, the vertical (z) axis is no longer directly aligned with gravity,
 so the blue decreases, and red increases because gravity is now pulling more
@@ -14,9 +14,9 @@ This video walks you through the code: https://youtu.be/eNpPLbYx-iA
 """
 
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.brightness = 0.2  # Adjust overall brightness as desired, between 0 and 1
+cp.pixels.brightness = 0.2  # Adjust overall brightness as desired, between 0 and 1
 
 
 def color_amount(accel_component):
@@ -41,8 +41,8 @@ def log_values():
 
 
 while True:
-    acceleration = cpx.acceleration
+    acceleration = cp.acceleration
     rgb_amounts = [color_amount(axis_value) for axis_value in acceleration]
-    cpx.pixels.fill(rgb_amounts)
+    cp.pixels.fill(rgb_amounts)
     log_values()
     time.sleep(0.1)

--- a/examples/advanced_examples/circuitplayground_gravity_pulls_pixel.py
+++ b/examples/advanced_examples/circuitplayground_gravity_pulls_pixel.py
@@ -1,6 +1,6 @@
 """Gravity Pulls Pixel
 
-This program uses the Circuit Playground Express’s accelerometer to position
+This program uses the Circuit Playground's accelerometer to position
 a white pixel as if gravity were pulling it.
 
 Flip the switch left (toward the notes) to turn on debugging messages and
@@ -8,7 +8,7 @@ slow down the action. See a code walkthrough here: https://youtu.be/sZ4tNOUKRpw
 """
 import time
 import math
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 PIXEL_SPACING_ANGLE = 30
 STANDARD_GRAVITY = 9.81
@@ -21,12 +21,12 @@ LIGHTING_ARC_LENGTH = 45
 def compute_pixel_angles():
     """Return a list of rotation angles of the ten NeoPixels.
 
-    On the CPX there are ten pixels arranged like the 12 hours of a clock, except that positions
-    6 and 12 are empty. The numbers in the list are the angles from the (x, y) accelerometer
-    values for each pixel when the CPX is rotated with that pixel at the bottom. For example,
-    with pixel 0 at the bottom (and pixel 5 at the top), the accelerometer’s (x, y) values
-    give an angle of 300°. Rotated clockwise 1/12 turn (30°), so that pixel 1 is at the bottom,
-    the angle is 330°.
+    On the Circuit Playground there are ten pixels arranged like the 12 hours of a clock, except
+    that positions 6 and 12 are empty. The numbers in the list are the angles from the (x, y)
+    accelerometer values for each pixel when the Circuit Playground is rotated with that pixel at
+    the bottom. For example, with pixel 0 at the bottom (and pixel 5 at the top), the
+    accelerometer’s (x, y) values give an angle of 300°. Rotated clockwise 1/12 turn (30°), so
+    that pixel 1 is at the bottom, the angle is 330°.
     """
     return [(300 + PIXEL_SPACING_ANGLE * n) % 360 for n in range(12) if n not in (5, 11)]
 
@@ -60,12 +60,12 @@ def positive_degrees(angle):
     return (angle + 360) % 360
 
 
-cpx.pixels.brightness = 0.1  # Adjust overall brightness as desired, between 0 and 1
+cp.pixels.brightness = 0.1  # Adjust overall brightness as desired, between 0 and 1
 pixel_positions = compute_pixel_angles()
 
 while True:
-    debug = cpx.switch  # True is toward the left
-    accel_x, accel_y = cpx.acceleration[:2]  # Ignore z
+    debug = cp.switch  # True is toward the left
+    accel_x, accel_y = cp.acceleration[:2]  # Ignore z
     down_angle = positive_degrees(angle_in_degrees(accel_x, accel_y))
     magnitude_limit = STANDARD_GRAVITY
     normalized_magnitude = min(math.sqrt(accel_x * accel_x + accel_y * accel_y),
@@ -74,7 +74,7 @@ while True:
     pixels_lit = []
     for i, pixel_position in enumerate(pixel_positions):
         pe = pixel_brightness(degrees_between(pixel_position, down_angle), normalized_magnitude)
-        cpx.pixels[i] = (pe, pe, pe) if pe else BACKGROUND_COLOR
+        cp.pixels[i] = (pe, pe, pe) if pe else BACKGROUND_COLOR
         if pe:
             pixels_lit.append((i, pe))
 

--- a/examples/advanced_examples/circuitplayground_tilting_arpeggios.py
+++ b/examples/advanced_examples/circuitplayground_tilting_arpeggios.py
@@ -4,14 +4,15 @@ This program plays notes from arpeggios in a circle of fourths. Y-axis tilt choo
 Buttons A and B advance forward and backward through the circle. The switch selects
 the type of arpeggio, either dominant seventh or blues.
 
-You can ignore the FrequencyProvider class if you’re just interested in the CPX interface.
+You can ignore the FrequencyProvider class if you’re just interested in the Circuit Playground
+interface.
 
 See a code walkthrough here: https://www.youtube.com/watch?v=cDhqyT3ZN0g
 """
 
 # pylint: disable=R0903
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 HS_OCT = 12                 # Half-steps per octave
 HS_4TH = 5                  # Half-steps in a fourth
@@ -65,11 +66,11 @@ class FrequencyMaker:
 class ButtonDetector:
     def __init__(self):
         self.next_press_allowed_at = time.monotonic()
-        self.buttons_on = (cpx.button_a, cpx.button_b)
+        self.buttons_on = (cp.button_a, cp.button_b)
 
     def pressed(self, index):
         """Return whether the specified button (0=A, 1=B) was pressed, limiting the repeat rate"""
-        pressed = cpx.button_b if index else cpx.button_a
+        pressed = cp.button_b if index else cp.button_a
         if pressed:
             now = time.monotonic()
             if now >= self.next_press_allowed_at:
@@ -80,7 +81,7 @@ class ButtonDetector:
 
 class TiltingArpeggios:
     def __init__(self):
-        cpx.pixels.brightness = 0.2
+        cp.pixels.brightness = 0.2
         self.freq_maker = FrequencyMaker()
         TiltingArpeggios.update_pixel(self.freq_maker.circle_pos)
         self.button = ButtonDetector()
@@ -97,18 +98,18 @@ class TiltingArpeggios:
     @staticmethod
     def update_pixel(circle_pos):
         """Manage the display on the NeoPixels of the current circle position"""
-        cpx.pixels.fill((0, 0, 0))
+        cp.pixels.fill((0, 0, 0))
         # Light the pixels clockwise from “1 o’clock” with the USB connector on the bottom
         pixel_index = (4 - circle_pos) % 10
         # Use a different color after all ten LEDs used
         color = (0, 255, 0) if circle_pos <= 9 else (255, 255, 0)
-        cpx.pixels[pixel_index] = color
+        cp.pixels[pixel_index] = color
 
     @staticmethod
     def tilt():
         """Normalize the Y-Axis Tilt"""
         standard_gravity = 9.81  # Acceleration (m/s²) due to gravity at the earth’s surface
-        constrained_accel = min(max(0.0, -cpx.acceleration[1]), standard_gravity)
+        constrained_accel = min(max(0.0, -cp.acceleration[1]), standard_gravity)
         return constrained_accel / standard_gravity
 
     def process_button_presses(self):
@@ -120,12 +121,12 @@ class TiltingArpeggios:
 
     def change_tone_if_needed(self):
         """Find the frequency for the current arpeggio and tilt, and restart the tone if changed"""
-        arpeggio_index = 0 if cpx.switch else 1
+        arpeggio_index = 0 if cp.switch else 1
         freq = self.freq_maker.freq(TiltingArpeggios.tilt(), arpeggio_index)
         if freq != self.last_freq:
             self.last_freq = freq
-            cpx.stop_tone()
-            cpx.start_tone(freq)
+            cp.stop_tone()
+            cp.start_tone(freq)
 
 
 TiltingArpeggios().run()

--- a/examples/circuitplayground_acceleration.py
+++ b/examples/circuitplayground_acceleration.py
@@ -1,8 +1,8 @@
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    x, y, z = cpx.acceleration
+    x, y, z = cp.acceleration
     print(x, y, z)
 
     time.sleep(0.1)

--- a/examples/circuitplayground_acceleration.py
+++ b/examples/circuitplayground_acceleration.py
@@ -1,3 +1,5 @@
+"""This example uses the accelerometer on the Circuit Playground. It prints the values. Try moving
+the board to see the values change."""
 import time
 from adafruit_circuitplayground import cp
 

--- a/examples/circuitplayground_acceleration_neopixels.py
+++ b/examples/circuitplayground_acceleration_neopixels.py
@@ -1,21 +1,21 @@
 """If the switch is to the right, it will appear that nothing is happening. Move the switch to the
-left to see the NeoPixels light up in colors related to the accelerometer! The CPX has an
-accelerometer in the center that returns (x, y, z) acceleration values. This program uses those
-values to light up the NeoPixels based on those acceleration values."""
-from adafruit_circuitplayground.express import cpx
+left to see the NeoPixels light up in colors related to the accelerometer! The Circuit Playground
+has an accelerometer in the center that returns (x, y, z) acceleration values. This program uses
+those values to light up the NeoPixels based on those acceleration values."""
+from adafruit_circuitplayground import cp
 
 # Main loop gets x, y and z axis acceleration, prints the values, and turns on
 # red, green and blue, at levels related to the x, y and z values.
 while True:
-    if not cpx.switch:
+    if not cp.switch:
         # If the switch is to the right, it returns False!
         print("Slide switch off!")
-        cpx.pixels.fill((0, 0, 0))
+        cp.pixels.fill((0, 0, 0))
         continue
     else:
         R = 0
         G = 0
         B = 0
-        x, y, z = cpx.acceleration
+        x, y, z = cp.acceleration
         print((x, y, z))
-        cpx.pixels.fill(((R + abs(int(x))), (G + abs(int(y))), (B + abs(int(z)))))
+        cp.pixels.fill(((R + abs(int(x))), (G + abs(int(y))), (B + abs(int(z)))))

--- a/examples/circuitplayground_button_a.py
+++ b/examples/circuitplayground_button_a.py
@@ -1,7 +1,7 @@
 """This example turns on the little red LED when button A is pressed."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    if cpx.button_a:
+    if cp.button_a:
         print("Button A pressed!")
-        cpx.red_led = True
+        cp.red_led = True

--- a/examples/circuitplayground_button_b.py
+++ b/examples/circuitplayground_button_b.py
@@ -1,14 +1,14 @@
 """This example turns the little red LED on only while button B is currently being pressed."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # This code is written to be readable versus being Pylint compliant.
 # pylint: disable=simplifiable-if-statement
 
 while True:
-    if cpx.button_b:
-        cpx.red_led = True
+    if cp.button_b:
+        cp.red_led = True
     else:
-        cpx.red_led = False
+        cp.red_led = False
 
 # Can also be written as:
-#    cpx.red_led = cpx.button_b
+#    cp.red_led = cp.button_b

--- a/examples/circuitplayground_buttons_1_neopixel.py
+++ b/examples/circuitplayground_buttons_1_neopixel.py
@@ -1,17 +1,17 @@
-﻿"""This example lights up the third NeoPixel while button A is being pressed, and lights up the
+"""This example lights up the third NeoPixel while button A is being pressed, and lights up the
 eighth NeoPixel while button B is being pressed."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.brightness = 0.3
-cpx.pixels.fill((0, 0, 0))  # Turn off the NeoPixels if they're on!
+cp.pixels.brightness = 0.3
+cp.pixels.fill((0, 0, 0))  # Turn off the NeoPixels if they're on!
 
 while True:
-    if cpx.button_a:
-        cpx.pixels[2] = (0, 255, 0)
+    if cp.button_a:
+        cp.pixels[2] = (0, 255, 0)
     else:
-        cpx.pixels[2] = (0, 0, 0)
+        cp.pixels[2] = (0, 0, 0)
 
-    if cpx.button_b:
-        cpx.pixels[7] = (0, 0, 255)
+    if cp.button_b:
+        cp.pixels[7] = (0, 0, 255)
     else:
-        cpx.pixels[7] = (0, 0, 0)
+        cp.pixels[7] = (0, 0, 0)

--- a/examples/circuitplayground_buttons_neopixels.py
+++ b/examples/circuitplayground_buttons_neopixels.py
@@ -1,17 +1,17 @@
-﻿"""This example lights up half the NeoPixels red while button A is being pressed, and half the
+"""This example lights up half the NeoPixels red while button A is being pressed, and half the
 NeoPixels green while button B is being pressed."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.brightness = 0.3
-cpx.pixels.fill((0, 0, 0))  # Turn off the NeoPixels if they're on!
+cp.pixels.brightness = 0.3
+cp.pixels.fill((0, 0, 0))  # Turn off the NeoPixels if they're on!
 
 while True:
-    if cpx.button_a:
-        cpx.pixels[0:5] = [(255, 0, 0)] * 5
+    if cp.button_a:
+        cp.pixels[0:5] = [(255, 0, 0)] * 5
     else:
-        cpx.pixels[0:5] = [(0, 0, 0)] * 5
+        cp.pixels[0:5] = [(0, 0, 0)] * 5
 
-    if cpx.button_b:
-        cpx.pixels[5:10] = [(0, 255, 0)] * 5
+    if cp.button_b:
+        cp.pixels[5:10] = [(0, 255, 0)] * 5
     else:
-        cpx.pixels[5:10] = [(0, 0, 0)] * 5
+        cp.pixels[5:10] = [(0, 0, 0)] * 5

--- a/examples/circuitplayground_ir_receive.py
+++ b/examples/circuitplayground_ir_receive.py
@@ -1,16 +1,21 @@
 """THIS EXAMPLE REQUIRES A SEPARATE LIBRARY BE LOADED ONTO YOUR CIRCUITPY DRIVE.
 This example requires the adafruit_irremote.mpy library.
 
+THIS EXAMPLE WORKS WITH CIRCUIT PLAYGROUND EXPRESS ONLY.
+
 This example uses the IR receiver found near the center of the board. Works with another Circuit
-Playground running the circuitplayground_ir_transmit.py example. The NeoPixels will light up when
-the buttons on the TRANSMITTING Circuit Playground are pressed!"""
+Playground Express running the circuitplayground_ir_transmit.py example. The NeoPixels will light
+up when the buttons on the TRANSMITTING Circuit Playground Express are pressed!"""
 import pulseio
 import board
 import adafruit_irremote
 from adafruit_circuitplayground import cp
 
 # Create a 'pulseio' input, to listen to infrared signals on the IR receiver
-pulsein = pulseio.PulseIn(board.IR_RX, maxlen=120, idle_state=True)
+try:
+    pulsein = pulseio.PulseIn(board.IR_RX, maxlen=120, idle_state=True)
+except AttributeError:
+    raise NotImplemented("This example does not work with Circuit Playground Bluefruti!")
 # Create a decoder that will take pulses and turn them into numbers
 decoder = adafruit_irremote.GenericDecode()
 

--- a/examples/circuitplayground_ir_receive.py
+++ b/examples/circuitplayground_ir_receive.py
@@ -1,13 +1,13 @@
 """THIS EXAMPLE REQUIRES A SEPARATE LIBRARY BE LOADED ONTO YOUR CIRCUITPY DRIVE.
 This example requires the adafruit_irremote.mpy library.
 
-This example uses the IR receiver found near the center of the board. Works with another CPX
-running the cpx_ir_transmit.py example. The NeoPixels will light up when the buttons on the
-TRANSMITTING CPX are pressed!"""
+This example uses the IR receiver found near the center of the board. Works with another Circuit
+Playground running the circuitplayground_ir_transmit.py example. The NeoPixels will light up when
+the buttons on the TRANSMITTING Circuit Playground are pressed!"""
 import pulseio
 import board
 import adafruit_irremote
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # Create a 'pulseio' input, to listen to infrared signals on the IR receiver
 pulsein = pulseio.PulseIn(board.IR_RX, maxlen=120, idle_state=True)
@@ -15,11 +15,11 @@ pulsein = pulseio.PulseIn(board.IR_RX, maxlen=120, idle_state=True)
 decoder = adafruit_irremote.GenericDecode()
 
 while True:
-    cpx.red_led = True
+    cp.red_led = True
     pulses = decoder.read_pulses(pulsein)
     try:
         # Attempt to convert received pulses into numbers
-        received_code = decoder.decode_bits(pulses, debug=False)
+        received_code = decoder.decode_bits(pulses)
     except adafruit_irremote.IRNECRepeatException:
         # We got an unusual short code, probably a 'repeat' signal
         continue
@@ -30,7 +30,7 @@ while True:
     print("Infrared code received: ", received_code)
     if received_code == [66, 84, 78, 65]:
         print("Button A signal")
-        cpx.pixels.fill((100, 0, 155))
+        cp.pixels.fill((100, 0, 155))
     if received_code == [66, 84, 78, 64]:
         print("Button B Signal")
-        cpx.pixels.fill((210, 45, 0))
+        cp.pixels.fill((210, 45, 0))

--- a/examples/circuitplayground_ir_receive.py
+++ b/examples/circuitplayground_ir_receive.py
@@ -15,7 +15,7 @@ from adafruit_circuitplayground import cp
 try:
     pulsein = pulseio.PulseIn(board.IR_RX, maxlen=120, idle_state=True)
 except AttributeError:
-    raise NotImplemented("This example does not work with Circuit Playground Bluefruti!")
+    raise NotImplementedError("This example does not work with Circuit Playground Bluefruti!")
 # Create a decoder that will take pulses and turn them into numbers
 decoder = adafruit_irremote.GenericDecode()
 

--- a/examples/circuitplayground_ir_transmit.py
+++ b/examples/circuitplayground_ir_transmit.py
@@ -1,9 +1,11 @@
 """THIS EXAMPLE REQUIRES A SEPARATE LIBRARY BE LOADED ONTO YOUR CIRCUITPY DRIVE.
 This example requires the adafruit_irremote.mpy library.
 
+THIS EXAMPLE WORKS WITH CIRCUIT PLAYGROUND EXPRESS ONLY.
+
 This example uses the IR transmitter found near the center of the board. Works with another Circuit
-Playground running the circuitplayground_ir_receive.py example. Press the buttons to light up the
-NeoPixels on the RECEIVING Circuit Playground!"""
+Playground Express running the circuitplayground_ir_receive.py example. Press the buttons to light
+up the NeoPixels on the RECEIVING Circuit Playground Express!"""
 import time
 import pulseio
 import board
@@ -11,7 +13,10 @@ import adafruit_irremote
 from adafruit_circuitplayground import cp
 
 # Create a 'pulseio' output, to send infrared signals from the IR transmitter
-pwm = pulseio.PWMOut(board.IR_TX, frequency=38000, duty_cycle=2 ** 15)
+try:
+    pwm = pulseio.PWMOut(board.IR_TX, frequency=38000, duty_cycle=2 ** 15)
+except AttributeError:
+    raise NotImplementedError("This example does not work with Circuit Playground Bluefruit!")
 pulseout = pulseio.PulseOut(pwm)
 # Create an encoder that will take numbers and turn them into NEC IR pulses
 encoder = adafruit_irremote.GenericTransmit(header=[9500, 4500], one=[550, 550],

--- a/examples/circuitplayground_ir_transmit.py
+++ b/examples/circuitplayground_ir_transmit.py
@@ -1,14 +1,14 @@
 """THIS EXAMPLE REQUIRES A SEPARATE LIBRARY BE LOADED ONTO YOUR CIRCUITPY DRIVE.
 This example requires the adafruit_irremote.mpy library.
 
-This example uses the IR transmitter found near the center of the board. Works with another CPX
-running the cpx_ir_receive.py example. Press the buttons to light up the NeoPixels on the RECEIVING
-CPX!"""
+This example uses the IR transmitter found near the center of the board. Works with another Circuit
+Playground running the circuitplayground_ir_receive.py example. Press the buttons to light up the
+NeoPixels on the RECEIVING Circuit Playground!"""
 import time
 import pulseio
 import board
 import adafruit_irremote
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # Create a 'pulseio' output, to send infrared signals from the IR transmitter
 pwm = pulseio.PWMOut(board.IR_TX, frequency=38000, duty_cycle=2 ** 15)
@@ -18,16 +18,16 @@ encoder = adafruit_irremote.GenericTransmit(header=[9500, 4500], one=[550, 550],
                                             zero=[550, 1700], trail=0)
 
 while True:
-    if cpx.button_a:
+    if cp.button_a:
         print("Button A pressed! \n")
-        cpx.red_led = True
+        cp.red_led = True
         encoder.transmit(pulseout, [66, 84, 78, 65])
-        cpx.red_led = False
+        cp.red_led = False
         # wait so the receiver can get the full message
         time.sleep(0.2)
-    if cpx.button_b:
+    if cp.button_b:
         print("Button B pressed! \n")
-        cpx.red_led = True
+        cp.red_led = True
         encoder.transmit(pulseout, [66, 84, 78, 64])
-        cpx.red_led = False
+        cp.red_led = False
         time.sleep(0.2)

--- a/examples/circuitplayground_light.py
+++ b/examples/circuitplayground_light.py
@@ -1,9 +1,9 @@
-"""This example uses the light sensor on your CPX, located next to the picture of the eye. Try
-shining a flashlight on your CPX, or covering the light sensor with your finger to see the values
-increase and decrease."""
+"""This example uses the light sensor on your Circuit Playground, located next to the picture of
+the eye. Try shining a flashlight on your Circuit Playground, or covering the light sensor with
+your finger to see the values increase and decrease."""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    print("Light:", cpx.light)
-    time.sleep(1)
+    print("Light:", cp.light)
+    time.sleep(0.2)

--- a/examples/circuitplayground_light_neopixels.py
+++ b/examples/circuitplayground_light_neopixels.py
@@ -1,14 +1,15 @@
 """
-This example uses the light sensor on the CPX, located next to the picture of the eye on the board.
-Once you have the library loaded, try shining a flashlight on your CPX to watch the number of
-NeoPixels lit up increase, or try covering up the light sensor to watch the number decrease.
+This example uses the light sensor on the Circuit Playground, located next to the picture of the
+eye on the board. Once you have the library loaded, try shining a flashlight on your Circuit
+Playground to watch the number of NeoPixels lit up increase, or try covering up the light sensor
+to watch the number decrease.
 """
 
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.auto_write = False
-cpx.pixels.brightness = 0.3
+cp.pixels.auto_write = False
+cp.pixels.brightness = 0.3
 
 
 def scale_range(value):
@@ -18,14 +19,14 @@ def scale_range(value):
 
 
 while True:
-    peak = scale_range(cpx.light)
-    print(cpx.light)
+    peak = scale_range(cp.light)
+    print(cp.light)
     print(int(peak))
 
     for i in range(10):
         if i <= peak:
-            cpx.pixels[i] = (0, 255, 255)
+            cp.pixels[i] = (0, 255, 255)
         else:
-            cpx.pixels[i] = (0, 0, 0)
-    cpx.pixels.show()
+            cp.pixels[i] = (0, 0, 0)
+    cp.pixels.show()
     time.sleep(0.05)

--- a/examples/circuitplayground_light_plotter.py
+++ b/examples/circuitplayground_light_plotter.py
@@ -1,10 +1,10 @@
 """If you're using Mu, this example will plot the light levels from the light sensor (located next
-to the eye) on your CPX. Try shining a flashlight on your CPX, or covering the light sensor to see
-the plot increase and decrease."""
+to the eye) on your Circuit Playground. Try shining a flashlight on your Circuit Playground, or
+covering the light sensor to see the plot increase and decrease."""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    print("Light:", cpx.light)
-    print((cpx.light,))
+    print("Light:", cp.light)
+    print((cp.light,))
     time.sleep(0.1)

--- a/examples/circuitplayground_neopixel_0_1.py
+++ b/examples/circuitplayground_neopixel_0_1.py
@@ -1,8 +1,8 @@
 """This example lights up the first and second NeoPixel, red and blue respectively."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.brightness = 0.3
+cp.pixels.brightness = 0.3
 
 while True:
-    cpx.pixels[0] = (255, 0, 0)
-    cpx.pixels[1] = (0, 0, 255)
+    cp.pixels[0] = (255, 0, 0)
+    cp.pixels[1] = (0, 0, 255)

--- a/examples/circuitplayground_pixels_simpletest.py
+++ b/examples/circuitplayground_pixels_simpletest.py
@@ -1,7 +1,7 @@
 # CircuitPython demo - NeoPixel
 
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # The number of pixels in the strip
 numpix = 10
@@ -23,14 +23,14 @@ def wheel(pos):
 
 def rainbow_cycle(wait):
     for j in range(255):
-        for i in range(cpx.pixels.n):
-            idx = int((i * 256 / len(cpx.pixels)) + j)
-            cpx.pixels[i] = wheel(idx & 255)
-        cpx.pixels.show()
+        for i in range(cp.pixels.n):
+            idx = int((i * 256 / len(cp.pixels)) + j)
+            cp.pixels[i] = wheel(idx & 255)
+        cp.pixels.show()
         time.sleep(wait)
 
 
-cpx.pixels.auto_write = False
-cpx.pixels.brightness = 0.3
+cp.pixels.auto_write = False
+cp.pixels.brightness = 0.3
 while True:
     rainbow_cycle(0.001)    # rainbowcycle with 1ms delay per step

--- a/examples/circuitplayground_pixels_simpletest.py
+++ b/examples/circuitplayground_pixels_simpletest.py
@@ -1,10 +1,6 @@
-# CircuitPython demo - NeoPixel
-
+"""This example lights up the NeoPixels with a rainbow swirl."""
 import time
 from adafruit_circuitplayground import cp
-
-# The number of pixels in the strip
-numpix = 10
 
 
 def wheel(pos):

--- a/examples/circuitplayground_play_file.py
+++ b/examples/circuitplayground_play_file.py
@@ -5,6 +5,6 @@ https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/tree/master
 Copy the "dip.wav" file to your CIRCUITPY drive.
 
 Once the file is copied, this example plays a wav file!"""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.play_file("dip.wav")
+cp.play_file("dip.wav")

--- a/examples/circuitplayground_play_file_buttons.py
+++ b/examples/circuitplayground_play_file_buttons.py
@@ -5,10 +5,10 @@ https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/tree/master
 Copy the "dip.wav" and "rise.wav" files to your CIRCUITPY drive.
 
 Once the files are copied, this example plays a different wav file for each button pressed!"""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    if cpx.button_a:
-        cpx.play_file("dip.wav")
-    if cpx.button_b:
-        cpx.play_file("rise.wav")
+    if cp.button_a:
+        cp.play_file("dip.wav")
+    if cp.button_b:
+        cp.play_file("rise.wav")

--- a/examples/circuitplayground_play_tone.py
+++ b/examples/circuitplayground_play_tone.py
@@ -1,6 +1,6 @@
 """This example plays two tones for 1 second each. Note that the tones are not in a loop - this is
 to prevent them from playing indefinitely!"""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.play_tone(262, 1)
-cpx.play_tone(294, 1)
+cp.play_tone(262, 1)
+cp.play_tone(294, 1)

--- a/examples/circuitplayground_play_tone_buttons.py
+++ b/examples/circuitplayground_play_tone_buttons.py
@@ -1,8 +1,8 @@
 """This example plays a different tone for a duration of 1 second for each button pressed."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    if cpx.button_a:
-        cpx.play_tone(262, 1)
-    if cpx.button_b:
-        cpx.play_tone(294, 1)
+    if cp.button_a:
+        cp.play_tone(262, 1)
+    if cp.button_b:
+        cp.play_tone(294, 1)

--- a/examples/circuitplayground_red_led.py
+++ b/examples/circuitplayground_red_led.py
@@ -1,5 +1,5 @@
 """This example turns on the little red LED."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    cpx.red_led = True
+    cp.red_led = True

--- a/examples/circuitplayground_red_led_blinky.py
+++ b/examples/circuitplayground_red_led_blinky.py
@@ -1,10 +1,10 @@
 """This is the "Hello, world!" of CircuitPython: Blinky! This example blinks the little red LED on
 and off!"""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    cpx.red_led = True
+    cp.red_led = True
     time.sleep(0.5)
-    cpx.red_led = False
+    cp.red_led = False
     time.sleep(0.5)

--- a/examples/circuitplayground_red_led_blnky_short.py
+++ b/examples/circuitplayground_red_led_blnky_short.py
@@ -1,8 +1,8 @@
 """This is the "Hello, world!" of CircuitPython: Blinky! This example blinks the little red LED on
 and off! It's a shorter version of the other Blinky example."""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    cpx.red_led = not cpx.red_led
+    cp.red_led = not cp.red_led
     time.sleep(0.5)

--- a/examples/circuitplayground_shake.py
+++ b/examples/circuitplayground_shake.py
@@ -1,5 +1,5 @@
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    if cpx.shake(shake_threshold=20):
+    if cp.shake(shake_threshold=20):
         print("Shake detected!")

--- a/examples/circuitplayground_shake.py
+++ b/examples/circuitplayground_shake.py
@@ -1,3 +1,4 @@
+"""This example prints to the serial console when the Circuit Playground is shaken."""
 from adafruit_circuitplayground import cp
 
 while True:

--- a/examples/circuitplayground_slide_switch.py
+++ b/examples/circuitplayground_slide_switch.py
@@ -1,8 +1,8 @@
 """This example prints the status of the slide switch. Try moving the switch back and forth to see
 what's printed to the serial console!"""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    print("Slide switch:", cpx.switch)
+    print("Slide switch:", cp.switch)
     time.sleep(0.1)

--- a/examples/circuitplayground_slide_switch_red_led.py
+++ b/examples/circuitplayground_slide_switch_red_led.py
@@ -1,11 +1,11 @@
 """This example uses the slide switch to control the little red LED."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # This code is written to be readable versus being Pylint compliant.
 # pylint: disable=simplifiable-if-statement
 
 while True:
-    if cpx.switch:
-        cpx.red_led = True
+    if cp.switch:
+        cp.red_led = True
     else:
-        cpx.red_led = False
+        cp.red_led = False

--- a/examples/circuitplayground_slide_switch_red_led_short.py
+++ b/examples/circuitplayground_slide_switch_red_led_short.py
@@ -1,6 +1,6 @@
 """This example uses the slide switch to control the little red LED. When the switch is to the
 right it returns False, and when it's to the left, it returns True."""
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    cpx.red_led = cpx.switch
+    cp.red_led = cp.switch

--- a/examples/circuitplayground_sound_meter.py
+++ b/examples/circuitplayground_sound_meter.py
@@ -1,11 +1,11 @@
 """This example uses the sound sensor, located next to the picture of the ear on your board, to
-light up the NeoPixels as a sound meter. Try talking to your CPX or clapping, etc, to see the
-NeoPixels light up!"""
+light up the NeoPixels as a sound meter. Try talking to your Circuit Playground or clapping, etc,
+to see the NeoPixels light up!"""
 import array
 import math
 import audiobusio
 import board
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 
 def constrain(value, floor, ceiling):
@@ -43,14 +43,14 @@ while True:
     c = log_scale(constrain(magnitude, input_floor, input_ceiling),
                   input_floor, input_ceiling, 0, 10)
 
-    cpx.pixels.fill((0, 0, 0))
+    cp.pixels.fill((0, 0, 0))
     for i in range(10):
         if i < c:
-            cpx.pixels[i] = (i * (255 // 10), 50, 0)
+            cp.pixels[i] = (i * (255 // 10), 50, 0)
         if c >= peak:
             peak = min(c, 10 - 1)
         elif peak > 0:
             peak = peak - 1
         if peak > 0:
-            cpx.pixels[int(peak)] = (80, 0, 255)
-    cpx.pixels.show()
+            cp.pixels[int(peak)] = (80, 0, 255)
+    cp.pixels.show()

--- a/examples/circuitplayground_tap_red_led.py
+++ b/examples/circuitplayground_tap_red_led.py
@@ -1,15 +1,15 @@
 """This example turns on the little red LED and prints to the serial console when you double-tap
-the CPX!"""
+the Circuit Playground!"""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # Change to 1 for detecting a single-tap!
-cpx.detect_taps = 2
+cp.detect_taps = 2
 
 while True:
-    if cpx.tapped:
+    if cp.tapped:
         print("Tapped!")
-        cpx.red_led = True
+        cp.red_led = True
         time.sleep(0.1)
     else:
-        cpx.red_led = False
+        cp.red_led = False

--- a/examples/circuitplayground_tapdetect.py
+++ b/examples/circuitplayground_tapdetect.py
@@ -1,7 +1,7 @@
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.detect_taps = 1
+cp.detect_taps = 1
 
 while True:
-    if cpx.tapped:
+    if cp.tapped:
         print("Single tap detected!")

--- a/examples/circuitplayground_tapdetect.py
+++ b/examples/circuitplayground_tapdetect.py
@@ -1,3 +1,4 @@
+"""This example prints to the serial console when the board is tapped."""
 from adafruit_circuitplayground import cp
 
 cp.detect_taps = 1

--- a/examples/circuitplayground_tapdetect_single_double.py
+++ b/examples/circuitplayground_tapdetect_single_double.py
@@ -1,3 +1,5 @@
+"""This example shows how you can use single-tap and double-tap together with a delay between.
+Single-tap the board twice and then double-tap the board twice to complete the program."""
 from adafruit_circuitplayground import cp
 
 # Set to check for single-taps.

--- a/examples/circuitplayground_tapdetect_single_double.py
+++ b/examples/circuitplayground_tapdetect_single_double.py
@@ -1,22 +1,22 @@
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 # Set to check for single-taps.
-cpx.detect_taps = 1
+cp.detect_taps = 1
 tap_count = 0
 
 # We're looking for 2 single-taps before moving on.
 while tap_count < 2:
-    if cpx.tapped:
+    if cp.tapped:
         tap_count += 1
 print("Reached 2 single-taps!")
 
 # Now switch to checking for double-taps
 tap_count = 0
-cpx.detect_taps = 2
+cp.detect_taps = 2
 
 # We're looking for 2 double-taps before moving on.
 while tap_count < 2:
-    if cpx.tapped:
+    if cp.tapped:
         tap_count += 1
 print("Reached 2 double-taps!")
 print("Done.")

--- a/examples/circuitplayground_temperature.py
+++ b/examples/circuitplayground_temperature.py
@@ -1,10 +1,10 @@
-"""This example uses the temperature sensor on the CPX, located next to the image of a thermometer
-on the board. It prints the temperature in both C and F to the serial console. Try putting your
-finger over the sensor to see the numbers change!"""
+"""This example uses the temperature sensor on the Circuit Playground, located next to the image of
+a thermometer on the board. It prints the temperature in both C and F to the serial console. Try
+putting your finger over the sensor to see the numbers change!"""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    print("Temperature C:", cpx.temperature)
-    print("Temperature F:", cpx.temperature * 1.8 + 32)
+    print("Temperature C:", cp.temperature)
+    print("Temperature F:", cp.temperature * 1.8 + 32)
     time.sleep(1)

--- a/examples/circuitplayground_temperature_neopixels.py
+++ b/examples/circuitplayground_temperature_neopixels.py
@@ -1,14 +1,14 @@
 """
-This example use the temperature sensor on the CPX, located next to the picture of the thermometer
-on the board. Try warming up the board to watch the number of NeoPixels lit up increase, or cooling
-it down to see the number decrease. You can set the min and max temperatures to make it more or
-less sensitive to temperature changes.
+This example use the temperature sensor on the Circuit Playground, located next to the picture of
+the thermometer on the board. Try warming up the board to watch the number of NeoPixels lit up
+increase, or cooling it down to see the number decrease. You can set the min and max temperatures
+to make it more or less sensitive to temperature changes.
 """
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.auto_write = False
-cpx.pixels.brightness = 0.3
+cp.pixels.auto_write = False
+cp.pixels.brightness = 0.3
 
 # Set these based on your ambient temperature in Celsius for best results!
 minimum_temp = 24
@@ -22,14 +22,14 @@ def scale_range(value):
 
 
 while True:
-    peak = scale_range(cpx.temperature)
-    print(cpx.temperature)
+    peak = scale_range(cp.temperature)
+    print(cp.temperature)
     print(int(peak))
 
     for i in range(10):
         if i <= peak:
-            cpx.pixels[i] = (0, 255, 255)
+            cp.pixels[i] = (0, 255, 255)
         else:
-            cpx.pixels[i] = (0, 0, 0)
-    cpx.pixels.show()
+            cp.pixels[i] = (0, 0, 0)
+    cp.pixels.show()
     time.sleep(0.05)

--- a/examples/circuitplayground_temperature_plotter.py
+++ b/examples/circuitplayground_temperature_plotter.py
@@ -1,4 +1,4 @@
-﻿"""If you're using Mu, this example will plot the temperature in C and F on the plotter! Click
+"""If you're using Mu, this example will plot the temperature in C and F on the plotter! Click
 "Plotter" to open it, and place your finger over the sensor to see the numbers change. The
 sensor is located next to the picture of the thermometer on the CPX."""
 import time

--- a/examples/circuitplayground_temperature_plotter.py
+++ b/examples/circuitplayground_temperature_plotter.py
@@ -2,10 +2,10 @@
 "Plotter" to open it, and place your finger over the sensor to see the numbers change. The
 sensor is located next to the picture of the thermometer on the CPX."""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    print("Temperature C:", cpx.temperature)
-    print("Temperature F:", cpx.temperature * 1.8 + 32)
-    print((cpx.temperature, cpx.temperature * 1.8 + 32))
+    print("Temperature C:", cp.temperature)
+    print("Temperature F:", cp.temperature * 1.8 + 32)
+    print((cp.temperature, cp.temperature * 1.8 + 32))
     time.sleep(0.1)

--- a/examples/circuitplayground_tone.py
+++ b/examples/circuitplayground_tone.py
@@ -1,9 +1,9 @@
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    if cpx.button_a:
-        cpx.start_tone(262)
-    elif cpx.button_b:
-        cpx.start_tone(294)
+    if cp.button_a:
+        cp.start_tone(262)
+    elif cp.button_b:
+        cp.start_tone(294)
     else:
-        cpx.stop_tone()
+        cp.stop_tone()

--- a/examples/circuitplayground_tone.py
+++ b/examples/circuitplayground_tone.py
@@ -1,3 +1,4 @@
+"""This example plays a different tone for each button, while the button is pressed."""
 from adafruit_circuitplayground import cp
 
 while True:

--- a/examples/circuitplayground_touch_pixel_fill_rainbow.py
+++ b/examples/circuitplayground_touch_pixel_fill_rainbow.py
@@ -1,31 +1,31 @@
-"""This example uses the capacitive touch pads on the CPX. They are located around the outer edge
-of the board and are labeled A1-A7. (A0 is not a touch pad.) This example lights up all the
-NeoPixels a different color of the rainbow for each pad touched!"""
+"""This example uses the capacitive touch pads on the Circuit Playground. They are located around
+the outer edge of the board and are labeled A1-A6 and TX. (A0 is not a touch pad.) This example
+lights up all the NeoPixels a different color of the rainbow for each pad touched!"""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.brightness = 0.3
+cp.pixels.brightness = 0.3
 
 while True:
-    if cpx.touch_A1:
+    if cp.touch_A1:
         print("Touched A1!")
-        cpx.pixels.fill((255, 0, 0))
-    if cpx.touch_A2:
+        cp.pixels.fill((255, 0, 0))
+    if cp.touch_A2:
         print("Touched A2!")
-        cpx.pixels.fill((210, 45, 0))
-    if cpx.touch_A3:
+        cp.pixels.fill((210, 45, 0))
+    if cp.touch_A3:
         print("Touched A3!")
-        cpx.pixels.fill((155, 100, 0))
-    if cpx.touch_A4:
+        cp.pixels.fill((155, 100, 0))
+    if cp.touch_A4:
         print("Touched A4!")
-        cpx.pixels.fill((0, 255, 0))
-    if cpx.touch_A5:
+        cp.pixels.fill((0, 255, 0))
+    if cp.touch_A5:
         print("Touched A5!")
-        cpx.pixels.fill((0, 135, 125))
-    if cpx.touch_A6:
+        cp.pixels.fill((0, 135, 125))
+    if cp.touch_A6:
         print("Touched A6!")
-        cpx.pixels.fill((0, 0, 255))
-    if cpx.touch_A7:
-        print("Touched A7!")
-        cpx.pixels.fill((100, 0, 155))
+        cp.pixels.fill((0, 0, 255))
+    if cp.touch_TX:
+        print("Touched TX!")
+        cp.pixels.fill((100, 0, 155))
     time.sleep(0.1)

--- a/examples/circuitplayground_touch_pixel_rainbow.py
+++ b/examples/circuitplayground_touch_pixel_rainbow.py
@@ -1,31 +1,31 @@
-"""This example uses the capacitive touch pads on the CPX. They are located around the outer edge
-of the board and are labeled A1-A7. (A0 is not a touch pad.) This example lights up the nearest
-NeoPixel to that pad a different color of the rainbow!"""
+"""This example uses the capacitive touch pads on the Circuit Playground. They are located around
+the outer edge of the board and are labeled A1-A6 and TX. (A0 is not a touch pad.) This example
+lights up the nearest NeoPixel to that pad a different color of the rainbow!"""
 import time
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
-cpx.pixels.brightness = 0.3
+cp.pixels.brightness = 0.3
 
 while True:
-    if cpx.touch_A1:
+    if cp.touch_A1:
         print("Touched A1!")
-        cpx.pixels[6] = (255, 0, 0)
-    if cpx.touch_A2:
+        cp.pixels[6] = (255, 0, 0)
+    if cp.touch_A2:
         print("Touched A2!")
-        cpx.pixels[8] = (210, 45, 0)
-    if cpx.touch_A3:
+        cp.pixels[8] = (210, 45, 0)
+    if cp.touch_A3:
         print("Touched A3!")
-        cpx.pixels[9] = (155, 100, 0)
-    if cpx.touch_A4:
+        cp.pixels[9] = (155, 100, 0)
+    if cp.touch_A4:
         print("Touched A4!")
-        cpx.pixels[0] = (0, 255, 0)
-    if cpx.touch_A5:
+        cp.pixels[0] = (0, 255, 0)
+    if cp.touch_A5:
         print("Touched A5!")
-        cpx.pixels[1] = (0, 135, 125)
-    if cpx.touch_A6:
+        cp.pixels[1] = (0, 135, 125)
+    if cp.touch_A6:
         print("Touched A6!")
-        cpx.pixels[3] = (0, 0, 255)
-    if cpx.touch_A7:
-        print("Touched A7!")
-        cpx.pixels[4] = (100, 0, 155)
+        cp.pixels[3] = (0, 0, 255)
+    if cp.touch_TX:
+        print("Touched TX!")
+        cp.pixels[4] = (100, 0, 155)
     time.sleep(0.1)

--- a/examples/circuitplayground_touched.py
+++ b/examples/circuitplayground_touched.py
@@ -1,3 +1,4 @@
+"""This example prints to the serial console when you touch the capacitive touch pads."""
 from adafruit_circuitplayground import cp
 
 while True:

--- a/examples/circuitplayground_touched.py
+++ b/examples/circuitplayground_touched.py
@@ -1,17 +1,17 @@
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 while True:
-    if cpx.touch_A1:
+    if cp.touch_A1:
         print('Touched pad A1')
-    if cpx.touch_A2:
+    if cp.touch_A2:
         print('Touched pad A2')
-    if cpx.touch_A3:
+    if cp.touch_A3:
         print('Touched pad A3')
-    if cpx.touch_A4:
+    if cp.touch_A4:
         print('Touched pad A4')
-    if cpx.touch_A5:
+    if cp.touch_A5:
         print('Touched pad A5')
-    if cpx.touch_A6:
+    if cp.touch_A6:
         print('Touched pad A6')
-    if cpx.touch_A7:
-        print('Touched pad A7')
+    if cp.touch_TX:
+        print('Touched pad TX')


### PR DESCRIPTION
THIS IS A BREAKING CHANGE FOR THE UPDATED EXAMPLES. ALL PREVIOUS CODE WILL CONTINUE TO WORK AS-IS.

REQUIRES LATEST CHANGES TO CIRCUITPYTHON TO USE ON CIRCUIT PLAYGROUND EXPRESS. 5.x support for using this updated library on CPX requires this PR: https://github.com/adafruit/circuitpython/pull/2393 and there is a forthcoming PR for 4.x of the same nature that will be required to use the updated lib. 

As this library is frozen into the CPX build, we will be doing a new release of 4.x once all the fixes are in. For now, this update doesn't affect the current 4.1.0 because the frozen library has not been updated yet.

- You can now `from adafruit_circuitplayground import cp` and it will detect whether you are using a Circuit Playground Express or a Circuit Playground Bluefruit and import the appropriate library.

- All examples have been updated to reflect this. THE EXAMPLES IN THIS REPO WILL NOW ONLY WORK WITH THE LATEST VERSION OF THE LIBRARY.

- Both `from adafruit_circuitplayground.express import cpx` and `from adafruit_circuitplayground.bluefruit import cpb` still work, so all previous example code will continue to work with the updated library.

- Updated doc strings to reflect changes - all references to CPX are now "Circuit Playground" to include the added Bluefruit support.

- Added exception handling to the IR examples as the Bluefruit does not support IR.

Tested every example on Circuit Playground Bluefruit, Circuit Playground Express 5.x test build, and Circuit Playground Express 4.x test build. 