### PR TITLE
Raise NotImplementedError if using non-Express features

### DIFF
--- a/adafruit_circuitplayground/express.py
+++ b/adafruit_circuitplayground/express.py
@@ -71,6 +71,17 @@ class Express(CircuitPlaygroundBase):
 
         super().__init__()
 
+    @property
+    def _unsupported(self):
+        """This feature is not supported on Circuit Playground Express."""
+        raise NotImplementedError("This feature is not supported on Circuit Playground Express.")
+
+    # The following is a list of the features available in other Circuit Playground modules but
+    # not available for Circuit Playground Express. If called while using a Circuit Playground
+    # Express, they will result in the NotImplementedError raised in the property above.
+    sound_level = _unsupported
+    loud_sound = _unsupported
+
 
 cpx = Express()  # pylint: disable=invalid-name
 """Object that is automatically created on import.


### PR DESCRIPTION
Adding a way to deal with potentially importing non-Express features when using the Circuit Playground Express and the `express` module. Written to be scalable as more features are added to Bluefruit, and more Circuit Playgrounds are added in the future.

Requires stack size increase to CircuitPython that is not part of the current beta, it is currently part of master. I would like to get this frozen into the next CircuitPython beta if possible.