### PR TITLE
adding support for mp3 files to play_file method.

### DIFF
--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -732,9 +732,10 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
         self._speaker_enable.value = False
 
     def play_file(self, file_name):
-        """ Play a .wav file using the onboard speaker.
+        """ Play a .wav or .mp3 file using the onboard speaker.
 
-        :param file_name: The name of your .wav file in quotation marks including .wav
+        :param file_name: The name of your .wav or .mp3 file in
+          quotation marks including .wav or .mp3
 
         .. image :: ../docs/_static/speaker.jpg
           :alt: Onboard speaker
@@ -755,12 +756,12 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
         self.stop_tone()
         self._speaker_enable.value = True
         with self._audio_out(board.SPEAKER) as audio:  # pylint: disable=not-callable
-            if ".wav" in file_name:
+            if file_name.lower().endswith(".wav"):
                 wavefile = audiocore.WaveFile(open(file_name, "rb"))
                 audio.play(wavefile)
                 while audio.playing:
                     pass
-            elif ".mp3" in file_name:
+            elif file_name.lower().endswith(".mp3"):
                 mp3file = audiomp3.MP3Decoder(open(file_name, "rb"))
                 audio.play(mp3file)
                 while audio.playing:

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -48,6 +48,7 @@ import analogio
 import board
 import busio
 import digitalio
+import audiomp3
 import adafruit_lis3dh
 import adafruit_thermistor
 import neopixel
@@ -754,8 +755,16 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
         self.stop_tone()
         self._speaker_enable.value = True
         with self._audio_out(board.SPEAKER) as audio:  # pylint: disable=not-callable
-            wavefile = audiocore.WaveFile(open(file_name, "rb"))
-            audio.play(wavefile)
-            while audio.playing:
-                pass
+            if ".wav" in file_name:
+                wavefile = audiocore.WaveFile(open(file_name, "rb"))
+                audio.play(wavefile)
+                while audio.playing:
+                    pass
+            elif ".mp3" in file_name:
+                mp3file = audiomp3.MP3Decoder(open(file_name, "rb"))
+                audio.play(mp3file)
+                while audio.playing:
+                    pass
+            else:
+                raise ValueError("Only supports .mp3 and .wav files")
         self._speaker_enable.value = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ autodoc_mock_imports = [
     "audiocore",
     "audiopwmio",
     "audiobusio",
+    "audiomp3",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Also raise a ValueError if the file supplied is not `.wav` or `.mp3`

Example usage:
```python
# wav still supported
cp.play_file("electrons.wav")
# mp3 also supported now
cp.play_file("test.mp3")
```
Tested on Circuit Playground Bluefruit only at this time. 