### PR TITLE
Add iteration support for touchpads

### DIFF
--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -83,9 +83,6 @@ class InterableInput:
             "The given padname is either not a valid touchpad or was deinitialized"
             )
 
-    def __contains__(self, value):
-        input_name = self._use_str_name(value)
-        return input_name in self._input_names
 
     def _use_str_name(self, value):
         """Converts an index into the pin name if needed"""

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -157,7 +157,7 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
                 "A4",
                 "A5",
                 "A6",
-                "A7",
+                "TX",
             ]
         )
         self._touch_threshold_adjustment = 0

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -72,14 +72,12 @@ class InterableInput:
 
     def __getitem__(self, index):
         input_name = self._use_str_name(index)
-        if isinstance(index, str):
-            for name, tio in zip(self._input_names, self._inputs):
-                if name == input_name:
-                    return tio
-            raise ValueError(
-                "The given padname is either not a valid touchpad or was deinitialized"
-                )
-        raise TypeError("Pin must be access either by int index or analog string name")
+        for name, tio in zip(self._input_names, self._inputs):
+            if name == input_name:
+                return tio
+        raise ValueError(
+            "The given padname is either not a valid touchpad or was deinitialized"
+            )
 
     def __contains__(self, value):
         input_name = self._use_str_name(value)

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -32,12 +32,6 @@ import adafruit_thermistor
 import neopixel
 import touchio
 
-try:
-    from typing import List
-    from microcontroller import Pin
-except ImportError:
-    pass
-
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground.git"
 
@@ -62,7 +56,7 @@ class InterableInput:
     :param name_list: A list of pin names to initialize as touchpad inputs
     """
 
-    def __init__(self, name_list: List[str]):
+    def __init__(self, name_list):
         self._input_names = name_list
         input_pins = [getattr(board, name) for name in name_list]
         self._inputs = [pin for pin in input_pins]

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -71,7 +71,6 @@ class InterableInput:
 
     def __iter__(self):
         for input_tio in self._inputs:
-            print(input_tio)
             yield input_tio
 
     def __getitem__(self, index):

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -66,10 +66,8 @@ class InterableInput:
         self._len_inputs = len(name_list)
 
     def __iter__(self):
-        return self
-
-    def __next__(self):
         for input_tio in self._inputs:
+            print(input_tio)
             yield input_tio
 
     def __getitem__(self, index):

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -427,12 +427,10 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
         self._touches.init_input(touchpad_pin)
 
     @property
-    def touched(self):
-        return [touch_pad for touch_pad in self._touches if touch_pad.value]
 
     @property
-    def touched_names(self):
-        list_touched = [touch_name for touch_pad, touch_name in zip(self._touches, self._touches.names) if touch_pad.value]
+    def touched(self):
+        return [touch_name for touch_pad, touch_name in zip(self._touches, self._touches.names) if touch_pad.value]
 
     # We chose these verbose touch_A# names so that beginners could use it without understanding
     # lists and the capital A to match the pin name. The capitalization is not strictly Python

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -427,6 +427,8 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
         self._touches.init_input(touchpad_pin)
 
     @property
+    def touchpads(self):
+        return self._touches.names
 
     @property
     def touched(self):

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -84,11 +84,16 @@ class InterableInput:
         return input_name in self._input_names
 
     def _use_str_name(self, value):
+        if value == 7 or value == "A7":
+            return "TX"
         if isinstance(value, int):
+            if value not in range(1, 7):
+                raise ValueError("Pins available as touchpads are 1-7")
             return "A" + str(value)
         if isinstance(value, str):
-            if value.startswith("A"):
-                return value
+            if not value.startswith("A") and int(value[1:]) not in range (1, 7):
+                raise ValueError("Pins available as touchpads are A1-A6 and A7/TX")
+            return value
         raise TypeError("Iterable inputs can only be accessed by int index or analog string names")
 
     def deinit_input(self, input_name):

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -459,7 +459,7 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
     @property
     def touchpads(self):
         """A list of all touchpad names currently set up as touchpad inputs"""
-        
+
         return self._touches.names
 
     @property

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -97,7 +97,7 @@ class InterableInput:
                 raise ValueError("Pins available as touchpads are 1-7")
             return "A" + str(value)
         if isinstance(value, str):
-            if not value.startswith("A") and int(value[1:]) not in range (1, 7):
+            if not value.startswith("A") and int(value[1:]) not in range(1, 7):
                 raise ValueError("Pins available as touchpads are A1-A6 and A7/TX")
             return value
         raise TypeError("Iterable inputs can only be accessed by int index or analog string names")

--- a/adafruit_circuitplayground/circuit_playground_base.py
+++ b/adafruit_circuitplayground/circuit_playground_base.py
@@ -52,14 +52,14 @@ class Photocell:
 
 class InterableInput:
     """Wrapper class for iterable touchpad inputs
-    
+
     :param name_list: A list of pin names to initialize as touchpad inputs
     """
 
     def __init__(self, name_list):
         self._input_names = name_list
         input_pins = [getattr(board, name) for name in name_list]
-        self._inputs = [pin for pin in input_pins]
+        self._inputs = list(input_pins)
         self._current_input = 0
         self._len_inputs = len(name_list)
 
@@ -74,7 +74,7 @@ class InterableInput:
                 return self._auto_convert_tio(tio)
         raise ValueError(
             "The given padname is either not a valid touchpad or was deinitialized"
-            )
+        )
 
     def _auto_convert_tio(self, input_pad):
         """Automagically turns an existing pin into a touchio.TouchIn as needed, and
@@ -87,10 +87,11 @@ class InterableInput:
             input_pad = self._inputs[name_index]
         return input_pad
 
-    def _use_str_name(self, value):
+    @staticmethod
+    def _use_str_name(value):
         """Converts an index into the pin name if needed"""
 
-        if value == 7 or value == "A7":
+        if value in (7, "A7", "TX"):
             return "TX"
         if isinstance(value, int):
             if value not in range(1, 7):
@@ -100,12 +101,14 @@ class InterableInput:
             if not value.startswith("A") and int(value[1:]) not in range(1, 7):
                 raise ValueError("Pins available as touchpads are A1-A6 and A7/TX")
             return value
-        raise TypeError("Iterable inputs can only be accessed by int index or analog string names")
+        raise TypeError(
+            "Iterable inputs can only be accessed by int index or analog string names"
+        )
 
     def deinit_input(self, input_name):
         """Deinitialize a given pin as a touchpad input, freeing up the memory and allowing the
         pin to be used as a different type of input
-        
+
         :param input_name: The name or pad number to be deinitialized
         :type input_name: str|int
         """
@@ -117,10 +120,10 @@ class InterableInput:
             selected_tio = self._inputs.pop(input_index)
             if isinstance(selected_tio, touchio.TouchIn):
                 selected_tio.deinit()
-        
+
     def init_input(self, input_name):
         """Initializes a given pin as a touchpad input, if not already
-        
+
         :param input_name: The name or pad number to be initialized
         :type input_name: str|int
         """
@@ -223,7 +226,7 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
     @staticmethod
     def _default_tap_threshold(tap):
         if (
-            "nRF52840" in os.uname().machine
+            "nRF52840" in os.uname().machine  # pylint: disable=no-member
         ):  # If we're on a CPB, use a higher tap threshold
             return 100 if tap == 1 else 70
 
@@ -440,7 +443,7 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
 
     def deinit_touchpad(self, touchpad_pin):
         """Deinitializes an input as a touchpad to free it up for use elsewhere
-        
+
         :param touchpad_pin: The touchpad name or number to deinitialize
         :type touchpad_pin: str|int
         """
@@ -449,7 +452,7 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
 
     def init_touchpad(self, touchpad_pin):
         """Initializes a pin as a touchpad input
-        
+
         :param touchpad_pin: The touchpad name or number to initialize
         :type touchpad_pin: str|int
         """
@@ -466,7 +469,11 @@ class CircuitPlaygroundBase:  # pylint: disable=too-many-public-methods
     def touched(self):
         """A list of touchpad input names currently registering as being touched"""
 
-        return [touch_name for touch_pad, touch_name in zip(self._touches, self._touches.names) if touch_pad.value]
+        return [
+            touch_name
+            for touch_pad, touch_name in zip(self._touches, self._touches.names)
+            if touch_pad.value
+        ]
 
     # We chose these verbose touch_A# names so that beginners could use it without understanding
     # lists and the capital A to match the pin name. The capitalization is not strictly Python

--- a/examples/circuitplayground_touch_all.py
+++ b/examples/circuitplayground_touch_all.py
@@ -10,3 +10,6 @@ print(cp.touchpads)
 while True:
     print("Touchpads currently registering a touch:")
     print(cp.touched)
+
+    if all(pad in cp.touched for pad in ("A2", "A3", "A4")):
+        print("This only prints when A2, A3, and A4 are being held at the same time!")

--- a/examples/circuitplayground_touch_all.py
+++ b/examples/circuitplayground_touch_all.py
@@ -4,18 +4,9 @@
 """This example prints to the serial console when you touch the capacitive touch pads."""
 from adafruit_circuitplayground import cp
 
+print("Here are all the possible touchpads:")
+print(cp.touchpads)
+
 while True:
-    if cp.touch_A1:
-        print("Touched pad A1")
-    if cp.touch_A2:
-        print("Touched pad A2")
-    if cp.touch_A3:
-        print("Touched pad A3")
-    if cp.touch_A4:
-        print("Touched pad A4")
-    if cp.touch_A5:
-        print("Touched pad A5")
-    if cp.touch_A6:
-        print("Touched pad A6")
-    if cp.touch_TX:
-        print("Touched pad TX")
+    print("Touchpads currently registering a touch:")
+    print(cp.touched)

--- a/examples/circuitplayground_touchpad_changing.py
+++ b/examples/circuitplayground_touchpad_changing.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2021 Alec Delaney
+# SPDX-License-Identifier: MIT
+
+"""This example prints to the serial console when you touch the capacitive touch pads."""
+from adafruit_circuitplayground import cp
+
+print("Here are all the initially registered touchpads:")
+print(cp.touchpads)
+
+print("You can remove a few if you need those pins:")
+cp.deinit_touchpad("A2")
+cp.deinit_touchpad("A5")
+print(cp.touchpads)
+
+print("You can also readd them later!")
+cp.init_touchpad("A2")
+print(cp.touchpads)


### PR DESCRIPTION
Resolves #103 as follows:

1. Adds `touched` property for showing list of of pin names currently registering a touch
2. Adds `touchpads` property got showing list of pin names that are set up as touchpad inputs
3. Continues to allow inputs to only be initialized as `touchio.TouchIn` as needed
4. Now allows for touchpads to be initialized and deinitialized as touchpad inputs, which allows those pins to be used for other things if wanted!
5. Existing methods for checking touchpads still works!
6. Modifies/adds examples to demonstrate new functionality

This is all powered by the new `IterableInput` class, which should remain hidden from the user but provides the above functionalities.