### PR TITLE
Add a subdirectory for CPX frozen modules

### DIFF
--- a/frozen_cpx/adafruit_circuitplayground/__init__.py
+++ b/frozen_cpx/adafruit_circuitplayground/__init__.py
@@ -1,0 +1,1 @@
+../../adafruit_circuitplayground/__init__.py

--- a/frozen_cpx/adafruit_circuitplayground/circuit_playground_base.py
+++ b/frozen_cpx/adafruit_circuitplayground/circuit_playground_base.py
@@ -1,0 +1,1 @@
+../../adafruit_circuitplayground/circuit_playground_base.py

--- a/frozen_cpx/adafruit_circuitplayground/express.py
+++ b/frozen_cpx/adafruit_circuitplayground/express.py
@@ -1,0 +1,1 @@
+../../adafruit_circuitplayground/express.py


### PR DESCRIPTION
Add a subdirectory in the repository with a copy of the library made using symbolic links excluding the CPB specific file.

This PR is required for [the Circuitpython core PR](https://github.com/adafruit/circuitpython/pull/6346) that changes the frozen directory to the `frozen_cpx` subdirectory, allowing to only freeze in the CPX version of the library, for a 1 kB gain in space.

I have tested it locally with the bundle release script and the library release script, and have seen no issue so far.

A possible issue would be the script finding the symbolic links and either spitting out an error (it expects only one main module per repository), or include them in the bundle, but it filters packages by prefix, and it expects the `adafruit_` prefix. As long as that doesn't change, we're fine. I think.