### PR TITLE
added exception on importing lib on a non-cp board

### DIFF
--- a/adafruit_circuitplayground/__init__.py
+++ b/adafruit_circuitplayground/__init__.py
@@ -10,3 +10,5 @@ if sys.platform == "nRF52840":
     from .bluefruit import cpb as cp
 elif sys.platform == "Atmel SAMD21":
     from .express import cpx as cp
+else:
+    raise ImportError(f"{sys.platform} not supported by this lib")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ autodoc_mock_imports = [
     "audiopwmio",
     "audiobusio",
     "audiomp3",
+    "circuit_playground_base",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Added an import exception if the platform is not recognized when importing the lib