### PR TITLE
Throw import exception when lib is used on an unsupported board

### DIFF
--- a/adafruit_circuitplayground/__init__.py
+++ b/adafruit_circuitplayground/__init__.py
@@ -6,7 +6,17 @@
 
 import sys
 
+
+class PlatformNotSupported:
+    """throws exception when used"""
+
+    def __getattribute__(self, *args, **kwargs):
+        raise ImportError(f"{sys.platform} not supported by this lib")
+
+
 if sys.platform == "nRF52840":
     from .bluefruit import cpb as cp
 elif sys.platform == "Atmel SAMD21":
     from .express import cpx as cp
+else:
+    cp = PlatformNotSupported()


### PR DESCRIPTION
Created a default cp object that throws an exception when attributes (e.g. functions) are accessed on an unsupported platform.  This object is returned by the lib's init when the platform is not recognized.  This change does not break Spinx and other CI tools that simply import the lib without using it.